### PR TITLE
scnaner: 调试发现extensions出现重复

### DIFF
--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -40,7 +40,7 @@ export class Scanner {
             conifgDir: DEFAULT_CONFIG_DIR,
             ...options,
             excluded: DEFAULT_EXCLUDES.concat(options.excluded ?? []),
-            extensions: this.moduleExtensions.concat(options.extensions ?? [], ['.yaml']),
+            extensions: [...new Set(this.moduleExtensions.concat(options.extensions ?? [], ['.yaml']))],
         };
 
         this.checkOptions();


### PR DESCRIPTION
defaultExtensions may contain same element with options.extensions