### PR TITLE
feat: support register custom loader check

### DIFF
--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -48,15 +48,4 @@ export const PLUGIN_META = ['meta.json', 'meta.yaml', 'meta.yml'];
 export const PACKAGE_JSON = 'package.json';
 export const EXCEPTION_FILE = 'artus-exception.yaml';
 
-export const DEFAULT_LOADER_LIST_WITH_ORDER = [
-  'exception',
-  'plugin-config',
-  'extension',
-  'config',
-  'plugin-meta',
-  'module',
-  'framework-config',
-  'package-json',
-];
-
 export const DEFAULT_CONFIG_DIR = 'src/config';

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -67,22 +67,24 @@ export class Scanner {
     }
 
     private registerDefaultLoaderCheck() {
-        // no checker
-        this.registerLoader('extension');
-        this.registerLoader('plugin-meta');
-        this.registerLoader('module');
-
-        // check filename
         this.registerLoader('exception', filename => isMatch(filename, EXCEPTION_FILE));
-        this.registerLoader('package-json', filename => isMatch(filename, PACKAGE_JSON));
 
-        // check within config path
         this.registerLoader('plugin-config',
             (filename, { baseDir, root }) => this.isConfigDir(baseDir, root) && isMatch(filename, PLUGIN_CONFIG_PATTERN));
+
+        this.registerLoader('extension');
+
         this.registerLoader('config',
             (filename, { baseDir, root }) => this.isConfigDir(baseDir, root) && isMatch(filename, CONFIG_PATTERN));
+
+        this.registerLoader('plugin-meta');
+
+        this.registerLoader('module');
+
         this.registerLoader('framework-config',
             (filename, { baseDir, root }) => this.isConfigDir(baseDir, root) && isMatch(filename, FRAMEWORK_PATTERN));
+
+        this.registerLoader('package-json', filename => isMatch(filename, PACKAGE_JSON));
     }
 
     public isConfigDir(baseDir: string, currentDir: string): boolean {


### PR DESCRIPTION
* 使用 `registerDefaultLoaderCheck` 替换内置的 DEFAULT_LOADER_LIST_WITH_ORDER 初始化
* 增加 `registerLoader` 允许外部 `Scanner` 实例在扫描阶段注册自定义 Loader 名称
* `Scanner` 判断文件所属 Loader 方式优化为：
  * 优先使用注册的 Loader Check 判断
  * 尝试从类 Reflect Metadata 中获取
  * 最后兜底为启动器内置的 `module` 加载