### PR TITLE
feat(scanner): 支持通过遍历 configDir 获得待扫描 env 列表

### DIFF
--- a/src/framework/handler.ts
+++ b/src/framework/handler.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import ConfigurationHandler, { ConfigObject } from '../configuration';
-import { ManifestItem } from "../types";
-import compatibleRequire from '../utils/compatible-require';
+import { ManifestItem } from '../types';
 
 export interface FrameworkConfig {
   path?: string,

--- a/src/framework/handler.ts
+++ b/src/framework/handler.ts
@@ -13,14 +13,7 @@ export class FrameworkHandler {
     frameworks = frameworks.filter(item => !done.includes(item.path));
     const frameworkConfigHandler = new ConfigurationHandler();
     for (const frameworkConfigFile of frameworks) {
-      const frameworkConfig = await compatibleRequire(frameworkConfigFile.path);
-      if (frameworkConfig) {
-        let [_, env, extname] = frameworkConfigFile.filename.split('.');
-        if (!extname) {
-          env = 'default';
-        }
-        frameworkConfigHandler.setConfig(env, frameworkConfig);
-      }
+      await frameworkConfigHandler.setConfigByFile(frameworkConfigFile);
     }
 
     done = done.concat(frameworks.map(item => item.path));

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -16,12 +16,12 @@ import {
     DEFAULT_LOADER,
     HOOK_FILE_LOADER,
     DEFAULT_CONFIG_DIR,
+    ARTUS_DEFAULT_CONFIG_ENV,
 } from '../constraints';
 import {
     ScannerOptions,
     WalkOptions,
     LoaderOptions,
-    ScanOptions,
 } from './types';
 import { Manifest, ManifestItem } from '../loader';
 import ConfigurationHandler from '../configuration';
@@ -55,10 +55,28 @@ export class Scanner {
         }
     }
 
-    public async scan(root: string, options: ScanOptions = { env: ['default'] }): Promise<Record<string, Manifest>> {
+    private async scanEnvList(root: string): Promise<string[]> {
+        const { configDir, envs } = this.options;
+        if (Array.isArray(envs) && envs.length) {
+          return envs;
+        }
+        const configFileList = await fs.readdir(path.resolve(root, configDir));
+        const envSet: Set<string> = new Set([ARTUS_DEFAULT_CONFIG_ENV.DEFAULT]);
+        for (const configFilename of configFileList) {
+          const env = ConfigurationHandler.getEnvFromFilename(configFilename);
+          envSet.add(env);
+        }
+        return [...envSet];
+    }
+
+    public async scan(root: string): Promise<Record<string, Manifest>> {
         const result = {};
-        for (const enviro of options.env) {
-            result[enviro] = await this.scanItems(root, enviro);
+        const envList = await this.scanEnvList(root);
+        for (const env of envList) {
+            result[env] = await this.scanItems(root, env);
+        }
+        if (this.options.needWriteFile) {
+            this.writeFile(`manifest.json`, JSON.stringify(result, null, 2));
         }
         return result;
     }
@@ -73,14 +91,7 @@ export class Scanner {
         // 2. Calculate Plugin Load Order (need scan after framework because of plugin config maybe in framework)
         const pluginConfigHandler = new ConfigurationHandler();
         for (const pluginConfigFile of this.itemMap.get('plugin-config') ?? []) {
-            const pluginConfig = await compatibleRequire(pluginConfigFile.path);
-            if (pluginConfig) {
-                let [_, env, extname] = pluginConfigFile.filename.split('.');
-                if (!extname) {
-                    env = 'default';
-                }
-                pluginConfigHandler.setConfig(env, pluginConfig);
-            }
+            await pluginConfigHandler.setConfigByFile(pluginConfigFile);
         }
         const mergedConfig = pluginConfigHandler.getMergedConfig(env);
         const pluginSortedList = await PluginFactory.createFromConfig(mergedConfig || {});
@@ -103,9 +114,6 @@ export class Scanner {
         const result: Manifest = {
             items: this.getItemsFromMap(),
         };
-        if (this.options.needWriteFile) {
-            this.writeFile(`manifest.${env}.json`, JSON.stringify(result, null, 2));
-        }
         return result;
     }
 

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -38,7 +38,7 @@ export class Scanner {
         this.options = {
             appName: 'app',
             needWriteFile: true,
-            conifgDir: DEFAULT_CONFIG_DIR,
+            configDir: DEFAULT_CONFIG_DIR,
             ...options,
             excluded: DEFAULT_EXCLUDES.concat(options.excluded ?? []),
             extensions: [...new Set(this.moduleExtensions.concat(options.extensions ?? [], ['.yaml']))],
@@ -50,7 +50,7 @@ export class Scanner {
     }
 
     private checkOptions() {
-        if (!this.options.conifgDir) {
+        if (!this.options.configDir) {
             throw new Error(`config dir must be passed in.`);
         }
     }
@@ -192,8 +192,8 @@ export class Scanner {
     }
 
     private isConfigDir(baseDir: string, currentDir: string): boolean {
-        const { conifgDir } = this.options;
-        return path.join(baseDir, conifgDir) === currentDir;
+        const { configDir } = this.options;
+        return path.join(baseDir, configDir) === currentDir;
     }
 
     private async getLoaderName(filename: string, { root, baseDir }: LoaderOptions): Promise<string> {

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -3,7 +3,7 @@ export interface ScannerOptions {
   extensions: string[];
   needWriteFile: boolean;
   excluded?: string[];
-  conifgDir: string
+  configDir: string
 }
 
 export interface ScanOptions {

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -4,10 +4,7 @@ export interface ScannerOptions {
   needWriteFile: boolean;
   excluded?: string[];
   configDir: string
-}
-
-export interface ScanOptions {
-  env: string[]
+  envs?: string[];
 }
 
 export interface WalkOptions {

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -17,9 +17,10 @@ describe('test/framework.test.ts', () => {
   it('should run succeed', async () => {
     const scanner = new Scanner({
       needWriteFile: false, extensions: ['.ts', '.js', '.json'],
-      configDir: 'src/config'
+      configDir: 'src/config',
+      envs: ['private']
     });
-    const { private: manifest } = await scanner.scan(path.resolve(__dirname, './fixtures/artus-application'), { env: ['private'] });
+    const { private: manifest } = await scanner.scan(path.resolve(__dirname, './fixtures/artus-application'));
     // console.log('manifest', manifest);
     const { main } = await import('./fixtures/artus-application/src');
     const app = await main(manifest);

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -17,7 +17,7 @@ describe('test/framework.test.ts', () => {
   it('should run succeed', async () => {
     const scanner = new Scanner({
       needWriteFile: false, extensions: ['.ts', '.js', '.json'],
-      conifgDir: 'src/config'
+      configDir: 'src/config'
     });
     const { private: manifest } = await scanner.scan(path.resolve(__dirname, './fixtures/artus-application'), { env: ['private'] });
     // console.log('manifest', manifest);


### PR DESCRIPTION
- scan 方法 envs 统一到 ScannerOptions
- options.envs 不传场景下，扫描 configDir 获得有效的 env 列表
- 配置文件 env 抽象工具方法
- ConfigurationHandler 抽象 setConfigByFile 减少 plugin/framework 重复代码