### PR TITLE
fix: should ignore d.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ export * from './decorator';
 export * from './types';
 export * from './constraints';
 
+import ConfigurationHandler from './configuration';
+export { ConfigurationHandler };
+
 import Trigger from './trigger';
 export { Trigger };
 

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -59,6 +59,9 @@ export class Scanner {
         const configFileList = await fs.readdir(path.resolve(root, configDir));
         const envSet: Set<string> = new Set([ARTUS_DEFAULT_CONFIG_ENV.DEFAULT]);
         for (const configFilename of configFileList) {
+            if(configFilename.endsWith('.d.ts')){
+              continue;
+            }
           const env = ConfigurationHandler.getEnvFromFilename(configFilename);
           envSet.add(env);
         }

--- a/test/fixtures/app-koa-with-ts/src/config/plugin.d.ts
+++ b/test/fixtures/app-koa-with-ts/src/config/plugin.d.ts
@@ -1,0 +1,7 @@
+declare const _default: {
+  redis: {
+      enable: boolean;
+      package: string;
+  };
+};
+export default _default;

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -5,7 +5,9 @@ import path from 'path';
 describe('test/scanner.test.ts', () => {
     it('should scan application', async () => {
         const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
-        const { default: manifest } = await scanner.scan(path.resolve(__dirname, './fixtures/app-koa-with-ts'));
+        const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app-koa-with-ts'));
+        const { default: manifest } = scanResults;
+        expect(Object.entries(scanResults).length).toBe(1);
         expect(manifest).toBeDefined();
         expect(manifest.items).toBeDefined();
         // console.log('manifest', manifest);


### PR DESCRIPTION
`tsc` 打包后会默认生成 `.d.ts` 声明文件，此时 Scanner 扫描 config 目录时对于 `plugin.ts` 等默认 Env 配置会错误扫描 `plugin.d.ts` 从而得到 Env `d`：

```js
{
  default: {
    items: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ]
  },
  d: {
    items: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ]
  }
}
```

需要在 Scanner 中忽略 `.d.ts` 申明文件
