### PR TITLE
feat: support relative path

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -1,5 +1,4 @@
 import 'reflect-metadata';
-import path from 'path';
 import { Container } from '@artus/injection';
 import { ArtusInjectEnum } from './constraints';
 import { ArtusStdError, ExceptionHandler } from './exception';
@@ -75,10 +74,6 @@ export class ArtusApplication implements Application {
   }
 
   async load(manifest: Manifest, root: string = process.cwd()) {
-    if (manifest.relative) {
-      manifest.items.forEach(item => item.path = path.join(root, item.path));
-    }
-
     if (!this.defaultClazzLoaded) {
       await this.loadDefaultClass();
     }
@@ -86,7 +81,7 @@ export class ArtusApplication implements Application {
     // Load user manifest
     this.manifest = manifest;
 
-    await this.loaderFactory.loadManifest(manifest);
+    await this.loaderFactory.loadManifest(manifest, manifest.relative ? root : undefined);
 
     await this.lifecycleManager.emitHook('didLoad');
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import path from 'path';
 import { Container } from '@artus/injection';
 import { ArtusInjectEnum } from './constraints';
 import { ArtusStdError, ExceptionHandler } from './exception';
@@ -73,7 +74,11 @@ export class ArtusApplication implements Application {
     this.defaultClazzLoaded = true;
   }
 
-  async load(manifest: Manifest) {
+  async load(manifest: Manifest, root: string = process.cwd()) {
+    if (manifest.relative) {
+      manifest.items.forEach(item => item.path = path.join(root, item.path));
+    }
+
     if (!this.defaultClazzLoaded) {
       await this.loadDefaultClass();
     }

--- a/src/loader/factory.ts
+++ b/src/loader/factory.ts
@@ -31,7 +31,7 @@ export class LoaderFactory {
     return this.container.get(ConfigurationHandler);
   }
 
-  async loadManifest(manifest: Manifest): Promise<void> {
+  async loadManifest(manifest: Manifest, root?: string): Promise<void> {
     await this.loadItemList(manifest.items, {
       config: {
         before: () => this.lifecycleManager.emitHook('configWillLoad'),
@@ -55,12 +55,13 @@ export class LoaderFactory {
           value: this.configurationHandler.getPackages()
         })
       }
-    });
+    }, root);
   }
 
-  async loadItemList(itemList: ManifestItem[] = [], hookMap?: Record<string, LoaderHookUnit>): Promise<void> {
+  async loadItemList(itemList: ManifestItem[] = [], hookMap?: Record<string, LoaderHookUnit>, root?: string): Promise<void> {
     let prevLoader: string = '';
     for (const item of itemList) {
+      item.path = root ? path.join(root, item.path) : item.path;
       const curLoader = item.loader ?? DEFAULT_LOADER;
       if (item.loader !== prevLoader) {
         if (prevLoader) {
@@ -99,7 +100,7 @@ export class LoaderFactory {
     const target = await compatibleRequire(path.join(root, filename));
     const metadata = Reflect.getMetadata(HOOK_FILE_LOADER, target);
     if (metadata?.loader) {
-        return metadata.loader;
+      return metadata.loader;
     }
 
     // default loder

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -2,6 +2,7 @@ import { Container } from '@artus/injection';
 
 interface Manifest {
   items: ManifestItem[];
+  relative?: boolean;
 }
 
 interface ManifestItem extends Record<string, any> {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -111,7 +111,8 @@ export class Scanner {
     await this.walk(root, this.formatWalkOptions('app', root, ''));
 
     const result: Manifest = {
-      items: this.getItemsFromMap()
+      items: this.getItemsFromMap(this.options.useRelativePath, root),
+      relative: this.options.useRelativePath,
     }
     return result;
   }
@@ -177,11 +178,12 @@ export class Scanner {
     return Object.assign({}, commonOptions, { source, baseDir, unitName, configDir });
   }
 
-  private getItemsFromMap(): ManifestItem[] {
+  private getItemsFromMap(relative: boolean, appRoot: string): ManifestItem[] {
     let items: ManifestItem[] = [];
     for (const [, unitItems] of this.itemMap) {
       items = items.concat(unitItems);
     }
+    relative && (items.forEach(item => item.path = path.relative(appRoot, item.path)));
     return items;
   }
 

--- a/test/fixtures/artus_application/src/index.ts
+++ b/test/fixtures/artus_application/src/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { Manifest, ArtusApplication, ArtusInjectEnum } from "../../../../src";
 import { AbstractBar } from '../../frameworks/bar/src';
 import { Inject, Injectable } from "@artus/injection"
@@ -13,7 +14,7 @@ export default class MyArtusApplication {
 
   static async instance(manifest: Manifest): Promise<MyArtusApplication> {
     const app = new ArtusApplication();
-    await app.load(manifest);
+    await app.load(manifest, path.join(__dirname, '..'));
     const instance = app.getContainer().get(MyArtusApplication);
     return instance;
   }


### PR DESCRIPTION
在 #81 的基础上，对 Manifest 增加了 `relative` 可选字段属性，如果为 true，则在启动期通过 `path.join` 应用根路径的形式启动，否则按照原有启动流程。

注意：此 feature 为在原有流程上的新增，不存在 `relative` 属性或者其为 `false` 时不会 break 原有启动和扫描流程。

close #79 