### PR TITLE
fix: 常量表命名 & 移除 const enum

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { Container } from '@artus/injection';
-import { ArtusInjectEnum } from './constraints';
+import { ArtusInjectEnum } from './constant';
 import { ArtusStdError, ExceptionHandler } from './exception';
 import { HookFunction, LifecycleManager } from './lifecycle';
 import { LoaderFactory, Manifest } from './loader';

--- a/src/configuration/decorator.ts
+++ b/src/configuration/decorator.ts
@@ -1,4 +1,4 @@
-import { HOOK_CONFIG_HANDLE } from "../constraints";
+import { HOOK_CONFIG_HANDLE } from "../constant";
 
 export function DefineConfigHandle(handleName?: string): PropertyDecorator {
   return (target: any, propertyKey: string | symbol) => {

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@artus/injection';
-import { ARTUS_DEFAULT_CONFIG_ENV, ARTUS_SERVER_ENV } from '../constraints';
+import { ARTUS_DEFAULT_CONFIG_ENV, ARTUS_SERVER_ENV } from '../constant';
 import { ManifestItem } from '../loader';
 import { mergeConfig } from '../loader/utils/merge';
 import compatibleRequire from '../utils/compatible_require';

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -3,7 +3,7 @@ export const LOADER_NAME_META = 'loader:name';
 
 export const ArtusInjectPrefix = 'artus#';
 
-export const enum ArtusInjectEnum {
+export enum ArtusInjectEnum {
   Application = 'artus#application',
   Config = 'artus#config',
   DefaultContainerName = 'artus#default_container',

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -5,7 +5,7 @@ import {
   HOOK_NAME_META_PREFIX,
   CONSTRUCTOR_PARAMS_CONTEXT,
   HOOK_FILE_LOADER,
-} from './constraints';
+} from './constant';
 
 export function LifecycleHookUnit(): ClassDecorator {
   return (target: any) => {

--- a/src/exception/error.ts
+++ b/src/exception/error.ts
@@ -1,4 +1,4 @@
-import { ARTUS_EXCEPTION_DEFAULT_LOCALE } from '../constraints';
+import { ARTUS_EXCEPTION_DEFAULT_LOCALE } from '../constant';
 import { ExceptionItem } from './types';
 
 export const ErrorCodeUtils = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
 
 export {
   ArtusInjectEnum
-} from './constraints';
+} from './constant';
 export * from './loader';
 export * from './lifecycle';
 export * from './exception';
@@ -16,7 +16,7 @@ export * from './application';
 export * from './scanner';
 export * from './decorator';
 export * from './types';
-export * from './constraints';
+export * from './constant';
 
 import ConfigurationHandler from './configuration';
 export { ConfigurationHandler };

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -5,7 +5,7 @@ import {
   CONSTRUCTOR_PARAMS_APP,
   CONSTRUCTOR_PARAMS_CONTAINER,
   HOOK_NAME_META_PREFIX
-} from '../constraints';
+} from '../constant';
 
 export type HookFunction = <T = unknown>(hookProps : {
   app: Application,

--- a/src/loader/decorator.ts
+++ b/src/loader/decorator.ts
@@ -1,4 +1,4 @@
-import { LOADER_NAME_META } from '../constraints';
+import { LOADER_NAME_META } from '../constant';
 
 export const DefineLoader = (loaderName: string): ClassDecorator => 
   (target: Function) => {

--- a/src/loader/factory.ts
+++ b/src/loader/factory.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { Container } from '@artus/injection';
-import { ArtusInjectEnum, DEFAULT_LOADER, HOOK_FILE_LOADER, LOADER_NAME_META } from '../constraints';
+import { ArtusInjectEnum, DEFAULT_LOADER, HOOK_FILE_LOADER, LOADER_NAME_META } from '../constant';
 import { Manifest, ManifestItem, LoaderConstructor, LoaderHookUnit, LoaderCheckOptions } from './types';
 import ConfigurationHandler from '../configuration';
 import { LifecycleManager } from '../lifecycle';

--- a/src/loader/impl/config.ts
+++ b/src/loader/impl/config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { Container } from '@artus/injection';
 import ConfigurationHandler from '../../configuration';
-import { ArtusInjectEnum, ARTUS_DEFAULT_CONFIG_ENV, CONFIG_PATTERN } from '../../constraints';
+import { ArtusInjectEnum, ARTUS_DEFAULT_CONFIG_ENV, CONFIG_PATTERN } from '../../constant';
 import { DefineLoader } from '../decorator';
 import { ManifestItem, Loader, LoaderCheckOptions } from '../types';
 import compatibleRequire from '../../utils/compatible_require';

--- a/src/loader/impl/exception.ts
+++ b/src/loader/impl/exception.ts
@@ -4,7 +4,7 @@ import { ManifestItem, Loader, LoaderCheckOptions } from '../types';
 import { ExceptionItem } from '../../exception/types';
 import { ExceptionHandler } from '../../exception';
 import { loadMetaFile } from '../../utils/load_meta_file';
-import { EXCEPTION_FILE } from '../../constraints';
+import { EXCEPTION_FILE } from '../../constant';
 import { isMatch } from '../../utils';
 
 @DefineLoader('exception')

--- a/src/loader/impl/framework_config.ts
+++ b/src/loader/impl/framework_config.ts
@@ -2,7 +2,7 @@ import ConfigurationHandler from '../../configuration';
 import { DefineLoader } from '../decorator';
 import { ManifestItem, Loader, LoaderCheckOptions } from '../types';
 import compatibleRequire from '../../utils/compatible_require';
-import { ArtusInjectEnum, ARTUS_DEFAULT_CONFIG_ENV, FRAMEWORK_PATTERN } from '../../constraints';
+import { ArtusInjectEnum, ARTUS_DEFAULT_CONFIG_ENV, FRAMEWORK_PATTERN } from '../../constant';
 import ConfigLoader from './config';
 import { isMatch } from '../../utils';
 

--- a/src/loader/impl/lifecycle.ts
+++ b/src/loader/impl/lifecycle.ts
@@ -1,5 +1,5 @@
 import { Constructable, Container } from '@artus/injection';
-import { ArtusInjectEnum } from '../../constraints';
+import { ArtusInjectEnum } from '../../constant';
 import { LifecycleManager } from '../../lifecycle';
 import { ApplicationLifecycle } from '../../types';
 import { DefineLoader } from '../decorator';

--- a/src/loader/impl/package.ts
+++ b/src/loader/impl/package.ts
@@ -3,7 +3,7 @@ import ConfigurationHandler from '../../configuration';
 import { DefineLoader } from '../decorator';
 import { ManifestItem, Loader, LoaderCheckOptions } from '../types';
 import compatibleRequire from '../../utils/compatible_require';
-import { PACKAGE_JSON } from '../../constraints';
+import { PACKAGE_JSON } from '../../constant';
 import { isMatch } from '../../utils';
 
 @DefineLoader('package-json')

--- a/src/loader/impl/plugin_config.ts
+++ b/src/loader/impl/plugin_config.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_CONFIG_PATTERN } from '../../constraints';
+import { PLUGIN_CONFIG_PATTERN } from '../../constant';
 import { isMatch } from '../../utils';
 import { DefineLoader } from '../decorator';
 import { ManifestItem, Loader, LoaderCheckOptions } from '../types';

--- a/src/logger/base.ts
+++ b/src/logger/base.ts
@@ -1,5 +1,5 @@
 import { Inject } from '@artus/injection';
-import { ArtusInjectEnum } from '../constraints';
+import { ArtusInjectEnum } from '../constant';
 import { LoggerLevel, LOGGER_LEVEL_MAP } from './level';
 import { Logger, LoggerOptions, LogOptions } from './types';
 

--- a/src/logger/decorator.ts
+++ b/src/logger/decorator.ts
@@ -1,5 +1,5 @@
 import { Injectable, ScopeEnum } from '@artus/injection';
-import { ArtusInjectEnum } from '../constraints';
+import { ArtusInjectEnum } from '../constant';
 
 export const DefineLogger = (): ClassDecorator => {
   return Injectable({

--- a/src/logger/level.ts
+++ b/src/logger/level.ts
@@ -1,4 +1,4 @@
-export const enum LoggerLevel {
+export enum LoggerLevel {
   TRACE = 'TRACE',
   DEBUG = 'DEBUG',
   INFO = 'INFO',

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,4 +1,4 @@
-export const enum PluginType {
+export enum PluginType {
   simple = 'simple',
   module = 'module',
 }

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -9,7 +9,7 @@ import {
   DEFAULT_EXCLUDES,
   DEFAULT_LOADER_LIST_WITH_ORDER,
   LOADER_NAME_META,
-} from '../constraints';
+} from '../constant';
 import { Manifest, ManifestItem } from '../loader';
 import { ScannerOptions, WalkOptions } from './types';
 import ConfigurationHandler, { ConfigObject } from '../configuration';

--- a/src/scanner/utils.ts
+++ b/src/scanner/utils.ts
@@ -7,7 +7,7 @@ import {
   ArtusInjectEnum,
   DEFAULT_LOADER,
   PLUGIN_META
-} from '../constraints';
+} from '../constant';
 import { LoaderFactory, ManifestItem } from '../loader';
 import { WalkOptions } from './types';
 import { isMatch } from '../utils';

--- a/src/trigger/decorator.ts
+++ b/src/trigger/decorator.ts
@@ -1,5 +1,5 @@
 import { Injectable, ScopeEnum } from '@artus/injection';
-import { ArtusInjectEnum } from '../constraints';
+import { ArtusInjectEnum } from '../constant';
 
 export function DefineTrigger(): ClassDecorator {
   return (target:any) => Injectable({

--- a/src/trigger/index.ts
+++ b/src/trigger/index.ts
@@ -1,6 +1,6 @@
 import { ExecutionContainer, Inject } from '@artus/injection';
 import { Input, Context, MiddlewareInput, Pipeline, Output } from '@artus/pipeline';
-import { ArtusInjectEnum } from '../constraints';
+import { ArtusInjectEnum } from '../constant';
 import { Application } from '../types';
 import { DefineTrigger } from './decorator';
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { ARTUS_SERVER_ENV } from '../src/constraints';
+import { ARTUS_SERVER_ENV } from '../src/constant';
 
 describe('test/app.test.ts', () => {
   describe('app with config', () => {

--- a/test/fixtures/frameworks/bar/src/http.ts
+++ b/test/fixtures/frameworks/bar/src/http.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { Context, Next } from '@artus/pipeline';
 import { Constructable } from '@artus/injection';
-import { CONSTRUCTOR_PARAMS, CONSTRUCTOR_PARAMS_CONTEXT } from '../../../../../src/constraints';
+import { CONSTRUCTOR_PARAMS, CONSTRUCTOR_PARAMS_CONTEXT } from '../../../../../src/constant';
 import { HttpTrigger } from '../../abstract/foo';
 import { Injectable, ScopeEnum } from '@artus/injection';
 

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -3,7 +3,7 @@ import { Scanner } from '../src/scanner';
 import path from 'path';
 import axios from 'axios';
 import assert from 'assert';
-import { ARTUS_SERVER_ENV } from '../src/constraints';
+import { ARTUS_SERVER_ENV } from '../src/constant';
 
 describe('test/framework.test.ts', () => {
   beforeEach(async function () {


### PR DESCRIPTION
- 修正错误命名 `constraint` 英语水平太差害死人
- 导出量中移除 const enum，方便下游对常量做扩展