### PR TITLE
chore: export configObject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ export * from './decorator';
 export * from './types';
 export * from './constant';
 
-import ConfigurationHandler from './configuration';
-export { ConfigurationHandler };
+import ConfigurationHandler, { ConfigObject } from './configuration';
+export { ConfigurationHandler, ConfigObject };
 
 import Trigger from './trigger';
 export { Trigger };


### PR DESCRIPTION
上层协议需要configObject这个类型。为了统一，上层不再重新定义