### PR TITLE
refactor: 支持 Plugin.package 字段在扫描阶段的预处理

### DIFF
--- a/src/loader/impl/config.ts
+++ b/src/loader/impl/config.ts
@@ -6,6 +6,12 @@ import { DefineLoader } from '../decorator';
 import { ManifestItem, Loader, LoaderFindOptions } from '../types';
 import compatibleRequire from '../../utils/compatible_require';
 import { isMatch } from '../../utils';
+import { Application } from '../../types';
+
+export interface ConfigFileMeta {
+  env: string;
+  namespace?: string;
+}
 
 @DefineLoader('config')
 class ConfigLoader implements Loader {
@@ -13,6 +19,14 @@ class ConfigLoader implements Loader {
 
   constructor(container) {
     this.container = container;
+  }
+
+  protected get app(): Application {
+    return this.container.get(ArtusInjectEnum.Application);
+  }
+
+  protected get configurationHandler(): ConfigurationHandler {
+    return this.container.get(ConfigurationHandler);
   }
 
   static async is(opts: LoaderFindOptions): Promise<boolean> {
@@ -28,24 +42,39 @@ class ConfigLoader implements Loader {
   }
 
   async load(item: ManifestItem) {
-    const originConfigObj = await compatibleRequire(item.path);
+    const { namespace, env } = await this.getConfigFileMeta(item);
+    let configObj = await this.loadConfigFile(item);
+    if (namespace) {
+      configObj = {
+        [namespace]: configObj
+      };
+    }
+    this.configurationHandler.setConfig(env, configObj);
+  }
+
+  protected async getConfigFileMeta(item: ManifestItem): Promise<ConfigFileMeta> {
     let [namespace, env, extname] = item.filename.split('.');
     if (!extname) {
       // No env flag, set to Default
       env = ARTUS_DEFAULT_CONFIG_ENV.DEFAULT;
     }
+    const meta: ConfigFileMeta = {
+      env
+    };
+    if (namespace !== 'config') {
+      meta.namespace = namespace;
+    }
+    return meta
+  }
+
+  protected async loadConfigFile(item: ManifestItem): Promise<Record<string, any>> {
+    const originConfigObj = await compatibleRequire(item.path);
     let configObj = originConfigObj;
     if(typeof originConfigObj === 'function') {
       const app = this.container.get(ArtusInjectEnum.Application);
       configObj = originConfigObj(app);
     }
-    if (namespace !== 'config') {
-      configObj = {
-        [namespace]: configObj
-      };
-    }
-    const configHandler = this.container.get(ConfigurationHandler);
-    configHandler.setConfig(env, configObj);
+    return configObj;
   }
 }
 

--- a/src/loader/impl/plugin_config.ts
+++ b/src/loader/impl/plugin_config.ts
@@ -23,6 +23,9 @@ class PluginConfigLoader extends ConfigLoader implements Loader {
       const pluginConfigItem: PluginConfigItem = configObj[pluginName];
       if (pluginConfigItem.package) {
         // convert package to path when load plugin config
+        if (pluginConfigItem.path) {
+          throw new Error(`Plugin ${pluginName} config can't have both package and path at ${item.path}`);
+        }
         if (pluginConfigItem.enable) {
           pluginConfigItem.path = ArtusPlugin.getPath(pluginConfigItem.package);
         }

--- a/src/plugin/base.ts
+++ b/src/plugin/base.ts
@@ -3,23 +3,29 @@ import path from 'path';
 type PluginMap = Map<string, BasePlugin>;
 
 export class BasePlugin implements Plugin {
+  static getPath(packageName: string): string {
+    return path.resolve(require.resolve(`${packageName}/package.json`), '..');
+  }
+
   public name: string;
   public enable: boolean;
-  public importPath: string;
+  public importPath: string = '';
   public metadata: Partial<PluginMetadata> = {};
   public metaFilePath: string = '';
 
   constructor(name: string, configItem: PluginConfigItem) {
     this.name = name;
-    let importPath = configItem.path ?? '';
-    if (configItem.package) {
-      importPath = path.resolve(require.resolve(`${configItem.package}/package.json`), '..');
-    }
-    if (!importPath) {
-      throw new Error(`Plugin ${name} need have path or package field`);
-    }
-    this.importPath = importPath;
     this.enable = configItem.enable ?? false;
+    if (this.enable) {
+      let importPath = configItem.path ?? '';
+      if (!importPath && configItem.package) {
+        importPath = BasePlugin.getPath(configItem.package);
+      }
+      if (!importPath) {
+        throw new Error(`Plugin ${name} need have path or package field`);
+      }
+      this.importPath = importPath;
+    }
   }
 
   async init() { }

--- a/src/plugin/base.ts
+++ b/src/plugin/base.ts
@@ -18,7 +18,10 @@ export class BasePlugin implements Plugin {
     this.enable = configItem.enable ?? false;
     if (this.enable) {
       let importPath = configItem.path ?? '';
-      if (!importPath && configItem.package) {
+      if (configItem.package) {
+        if (importPath) {
+          throw new Error(`plugin ${name} config error, package and path can't be set at the same time.`);
+        }
         importPath = BasePlugin.getPath(configItem.package);
       }
       if (!importPath) {

--- a/src/plugin/impl.ts
+++ b/src/plugin/impl.ts
@@ -5,6 +5,9 @@ import { exisis } from '../utils/fs';
 
 export class ArtusPlugin extends BasePlugin {
   async init() {
+    if (!this.enable) {
+      return;
+    }
     await this.checkAndLoadMetadata();
     if (!this.metadata) {
       throw new Error(`${this.name} is not have metadata.`);

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -21,8 +21,8 @@ export class Scanner {
   private moduleExtensions = ['.js', '.json', '.node'];
   private options: ScannerOptions;
   private itemMap: Map<string, ManifestItem[]> = new Map();
-  private tmpConfigStore: Map<string, ConfigObject[]>;
-  private configHandle: ConfigurationHandler;
+  private tmpConfigStore: Map<string, ConfigObject[]> = new Map();
+  private configHandle: ConfigurationHandler = new ConfigurationHandler();
 
   constructor(options: Partial<ScannerOptions> = {}) {
     this.options = {
@@ -35,8 +35,6 @@ export class Scanner {
       excluded: DEFAULT_EXCLUDES.concat(options.excluded ?? []),
       extensions: [...new Set(this.moduleExtensions.concat(options.extensions ?? [], ['.yaml']))],
     };
-    this.tmpConfigStore = new Map();
-    this.configHandle = new ConfigurationHandler();
   }
 
   private async initItemMap(): Promise<void> {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -236,7 +236,13 @@ export class Scanner {
       items = items.concat(unitItems);
     }
     relative && items.forEach(item => (item.path = path.relative(appRoot, item.path)));
-    return items;
+    return items.filter(item => {
+      if (item.loader === 'plugin-config') {
+        // remove PluginConfig to avoid re-merge on application running
+        return false;
+      }
+      return true;
+    });
   }
 
   private async writeFile(filename: string = 'manifest.json', data: string) {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -239,13 +239,10 @@ export class Scanner {
       items = items.concat(unitItems);
     }
     relative && items.forEach(item => (item.path = path.relative(appRoot, item.path)));
-    return items.filter(item => {
-      if (item.loader === 'plugin-config') {
-        // remove PluginConfig to avoid re-merge on application running
-        return false;
-      }
-      return true;
-    });
+    return items.filter(item => (
+      // remove PluginConfig to avoid re-merge on application running
+      item.loader !== 'plugin-config'
+    ));
   }
 
   private async writeFile(filename: string = 'manifest.json', data: string) {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -157,12 +157,16 @@ export class Scanner {
       if (ScanUtils.isExclude(filename, extname, this.options.excluded, this.options.extensions)) {
         return null;
       }
-      const loader = await loaderFactory.findLoaderName({
+      let loader = await loaderFactory.findLoaderName({
         filename,
         baseDir,
         root,
         configDir
       });
+      if (loader === 'framework-config') {
+        // SEEME: framework-config is a special loader, cannot be used when scan, need refactor later
+        loader = 'config';
+      }
       return {
         path: path.resolve(root, filename),
         extname,
@@ -172,7 +176,8 @@ export class Scanner {
       };
     }));
     await loaderFactory.loadItemList(configItemList.filter(v => v) as ManifestItem[]);
-    const config = container.get(ConfigurationHandler).getMergedConfig(env);
+    const configurationHandler = container.get(ConfigurationHandler);
+    const config = configurationHandler.getMergedConfig(env);
     let configList = [config];
     if (this.tmpConfigStore.has(env)) {
       // equal unshift config to configList

--- a/test/fixtures/app_koa_with_ts/src/config/plugin.default.ts
+++ b/test/fixtures/app_koa_with_ts/src/config/plugin.default.ts
@@ -9,4 +9,8 @@ export default {
     enable: false,
     path: path.resolve(__dirname, '../mysql_plugin')
   },
+  testDuplicate: {
+    enable: false,
+    package: 'unimportant-package'
+  },
 };

--- a/test/fixtures/app_koa_with_ts/src/config/plugin.dev.ts
+++ b/test/fixtures/app_koa_with_ts/src/config/plugin.dev.ts
@@ -1,0 +1,8 @@
+import path from 'path';
+
+export default {
+  testDuplicate: {
+    enable: true,
+    path: path.resolve(__dirname, '../test_duplicate_plugin')
+  },
+};

--- a/test/fixtures/app_koa_with_ts/src/test_duplicate_plugin/meta.yaml
+++ b/test/fixtures/app_koa_with_ts/src/test_duplicate_plugin/meta.yaml
@@ -1,0 +1,1 @@
+name: testDuplicate

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -12,9 +12,9 @@ describe('test/scanner.test.ts', () => {
         expect(manifest).toBeDefined();
         expect(manifest.items).toBeDefined();
         // console.log('manifest', manifest);
-        expect(manifest.items.length).toBe(13);
+        expect(manifest.items.length).toBe(11);
 
-        expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(2);
+        expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(0);
         expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
         expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);
         expect(manifest.items.filter(item => item.loader === 'lifecycle-hook-unit').length).toBe(2);
@@ -23,13 +23,13 @@ describe('test/scanner.test.ts', () => {
 
         expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
         expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
-        expect(manifest.items.filter(item => item.source === 'app').length).toBe(11);
+        expect(manifest.items.filter(item => item.source === 'app').length).toBe(9);
 
         const { dev: devManifest } = scanResults;
-        console.log('devManifest', devManifest);
+        // console.log('devManifest', devManifest);
         expect(devManifest).toBeDefined();
         expect(devManifest.items).toBeDefined();
-        expect(devManifest.items.length).toBe(14);
+        expect(devManifest.items.length).toBe(12);
         expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
         expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
     });

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -8,13 +8,13 @@ describe('test/scanner.test.ts', () => {
         const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
         const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app_koa_with_ts'));
         const { default: manifest } = scanResults;
-        expect(Object.entries(scanResults).length).toBe(1);
+        expect(Object.entries(scanResults).length).toBe(2);
         expect(manifest).toBeDefined();
         expect(manifest.items).toBeDefined();
         // console.log('manifest', manifest);
-        expect(manifest.items.length).toBe(12);
+        expect(manifest.items.length).toBe(13);
 
-        expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(1);
+        expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(2);
         expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
         expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);
         expect(manifest.items.filter(item => item.loader === 'lifecycle-hook-unit').length).toBe(2);
@@ -23,7 +23,15 @@ describe('test/scanner.test.ts', () => {
 
         expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
         expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
-        expect(manifest.items.filter(item => item.source === 'app').length).toBe(10);
+        expect(manifest.items.filter(item => item.source === 'app').length).toBe(11);
+
+        const { dev: devManifest } = scanResults;
+        console.log('devManifest', devManifest);
+        expect(devManifest).toBeDefined();
+        expect(devManifest.items).toBeDefined();
+        expect(devManifest.items.length).toBe(14);
+        expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
+        expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
     });
 
     it('should scan module with custom loader', async () => {


### PR DESCRIPTION
- Plugin 抽象 getPath 能力、增加 path/package 互斥判断
- Config 相关 Loader 重构，支持对 PluginConfig 进行预处理
- Scanner 局部逻辑重构
   - 重构 getAllConfig 兼容上述插件处理逻辑
   - 修正多环境条件下的配置数据隔离 BUG
   - 从 Manifest 中移除 PluginConfig，防止运行时对其的重新合并诱发两阶段配置状态不一致
 - 增加相关单元测试用例

resolve #109 