### PR TITLE
fix: sorted plugin list should not be reversed

### DIFF
--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -105,7 +105,7 @@ export class Scanner {
     }
     const { plugin } = this.configHandle.getMergedConfig(env);
     const pluginSortedList = await PluginFactory.createFromConfig(plugin || {});
-    for (const plugin of pluginSortedList.reverse()) {
+    for (const plugin of pluginSortedList) {
       if (!plugin.enable) continue;
       this.setPluginMeta(plugin);
       await this.walk(


### PR DESCRIPTION
最早的 Scanner 实现中遍历目录是倒序进行，因此拿到的排序后的 plugin 列表也需要 `reverse` 后遍历。

新版的 Scanner 已经是顺序扫描 framework -> plugin -> app 目录，这里的 `reverse` 会造成插件依赖顺序颠倒，此 PR 旨在修复此 BUG