### PR TITLE
refactor(scanner): modify exclude option for plugin & excluded rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "homepage": "https://github.com/artusjs/core#readme",
   "devDependencies": {
     "@artus/tsconfig": "0.0.1",
+    "@babel/core": "^7.18.6",
     "@types/jest": "^27.4.1",
     "@types/js-yaml": "^4.0.5",
     "@types/koa": "^2.13.4",

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -8,6 +8,7 @@ export interface PluginMetadata {
   dependencies?: PluginDependencyItem[];
   type?: PluginType;
   configDir?: string
+  exclude?: string[];
 }
 
 export interface PluginDependencyItem {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -111,7 +111,7 @@ export class Scanner {
       this.setPluginMeta(plugin);
       await this.walk(
         plugin.importPath,
-        this.formatWalkOptions('plugin', plugin.importPath, plugin.name, plugin.metadata)
+        this.formatWalkOptions('plugin', plugin.importPath, plugin.name, plugin.metadata),
       );
     }
 

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -217,18 +217,24 @@ export class Scanner {
   }
 
   private formatWalkOptions(source: string, baseDir: string, unitName?: string, metaInfo?: Partial<PluginMetadata>): WalkOptions {
-    return {
+    const opts: WalkOptions = {
       itemMap: this.itemMap,
       source,
       baseDir,
       unitName: unitName ?? baseDir,
       extensions: this.options.extensions,
-
-      // Meta of Plugin first, then use scanner options as default
-      // TODO: Only support plugin meta now, need cover framework meta later
-      exclude: metaInfo.exclude ?? this.options.exclude,
-      configDir: metaInfo.configDir ?? this.options.configDir,
+      exclude: this.options.exclude,
+      configDir: this.options.configDir,
     };
+
+    if (source === 'plugin') {
+      // TODO: Only support plugin meta now, need cover framework meta later
+      // Meta of Plugin first, then use default exclude from constant
+      opts.exclude = metaInfo.exclude ?? DEFAULT_EXCLUDES;
+      opts.configDir = metaInfo.configDir ?? this.options.configDir;
+    }
+
+    return opts;
   }
 
   private getItemsFromMap(relative: boolean, appRoot: string): ManifestItem[] {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -229,8 +229,7 @@ export class Scanner {
 
     if (source === 'plugin') {
       // TODO: Only support plugin meta now, need cover framework meta later
-      // Meta of Plugin first, then use default exclude from constant
-      opts.exclude = metaInfo.exclude ?? DEFAULT_EXCLUDES;
+      opts.exclude = DEFAULT_EXCLUDES.concat(metaInfo.exclude ?? []);
       opts.configDir = metaInfo.configDir ?? this.options.configDir;
     }
 

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -5,7 +5,7 @@ export interface ScannerOptions {
   extensions: string[];
   needWriteFile: boolean;
   useRelativePath: boolean;
-  excluded: string[];
+  exclude: string[];
   configDir: string;
   envs?: string[];
   loaderListGenerator: (defaultLoaderList: string[]) => (string | typeof BaseLoader)[];
@@ -16,7 +16,7 @@ export interface WalkOptions {
   baseDir: string;
   configDir: string;
   extensions: string[];
-  excluded: string[];
+  exclude: string[];
   itemMap: Map<string, ManifestItem[]>;
   unitName?: string;
 }

--- a/src/scanner/utils.ts
+++ b/src/scanner/utils.ts
@@ -32,7 +32,7 @@ export class ScanUtils {
     for (const item of items) {
       const realPath = path.resolve(root, item);
       const extname = path.extname(realPath);
-      if (this.isExclude(item, extname, options.excluded, options.extensions)) {
+      if (this.isExclude(item, extname, options.exclude, options.extensions)) {
         continue;
       }
       const itemStat = await fs.stat(realPath);
@@ -78,10 +78,10 @@ export class ScanUtils {
   }
 
   static isExclude(filename: string, extname: string,
-    excluded: string[], extensions: string[]): boolean {
+    exclude: string[], extensions: string[]): boolean {
     let result = false;
-    if (!result && excluded) {
-      result = isMatch(filename, excluded);
+    if (!result && exclude) {
+      result = isMatch(filename, exclude);
     }
 
     if (!result && extname) {

--- a/test/fixtures/app_koa_with_ts/src/redis_plugin/meta.yaml
+++ b/test/fixtures/app_koa_with_ts/src/redis_plugin/meta.yaml
@@ -1,1 +1,4 @@
 name: redis
+exclude:
+  - not_to_be_scanned_dir
+  - not_to_be_scanned_file.ts

--- a/test/fixtures/app_koa_with_ts/src/redis_plugin/not_to_be_scanned_dir/not_to_be_scanned_file.ts
+++ b/test/fixtures/app_koa_with_ts/src/redis_plugin/not_to_be_scanned_dir/not_to_be_scanned_file.ts
@@ -1,0 +1,1 @@
+export default class DummyClazz {}

--- a/test/fixtures/app_koa_with_ts/src/redis_plugin/not_to_be_scanned_file.ts
+++ b/test/fixtures/app_koa_with_ts/src/redis_plugin/not_to_be_scanned_file.ts
@@ -1,0 +1,1 @@
+export default class DummyClazz {}

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -14,6 +14,8 @@ describe('test/scanner.test.ts', () => {
     // console.log('manifest', manifest);
     expect(manifest.items.length).toBe(11);
 
+    expect(manifest.items.find(item => item.filename === 'not_to_be_scanned_file.ts')).toBeFalsy();
+
     expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(0);
     expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
     expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);


### PR DESCRIPTION
related #129 
改动点如下：
- BREAKING! Scanner 中所有 `excluded` 均调整为 `exclude`
- `Scanner.formatWalkOptions` 补充逻辑： `exclude` 使用默认常量序列 + 插件 Meta 中声明的 exclude 值（未声明为空）

对于 #129 实现中的其他部分：
- extensions 目前看不涉及单独配置，暂不考虑支持
- Framework 中目前未包括对 Metadata 的处理（不要求 meta.yaml），此处需要评估是否有必要增加，或在其他位置声明 exclude/configDir（如 package.json）cc @hyj1991 

cc @hyj1991  @JerrysShan @wengeezhang 