### PR TITLE
feat: basePlugin getPath support paths

### DIFF
--- a/src/plugin/base.ts
+++ b/src/plugin/base.ts
@@ -3,8 +3,9 @@ import path from 'path';
 type PluginMap = Map<string, BasePlugin>;
 
 export class BasePlugin implements Plugin {
-  static getPath(packageName: string): string {
-    return path.resolve(require.resolve(packageName), '..');
+  static getPath(packageName: string, paths?: string[]): string {
+    const requireOpts = paths ? { paths } : {};
+    return path.resolve(require.resolve(packageName, requireOpts), '..');
   }
 
   public name: string;


### PR DESCRIPTION
背景：
目前 plugin 的寻址策略是由 artus/core 底层确定的，这个策略可能会随着时间而改动。  上层协议或者 cli 工具直接调用 BasePlugin.getPath 即可。

现在的 BasePlugin.getPath 不支持 paths , 导致在某些场景（比如全局安装 cli ）下，找不到