### PR TITLE
fix: lifecycle hook should trigger only one time

### DIFF
--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -68,6 +68,8 @@ export class LifecycleManager {
     if (!Array.isArray(fnList)) {
       return;
     }
+    // lifecycle hook should only trigger one time
+    this.hookFnMap.delete(hookName);
     for (const hookFn of fnList) {
       await hookFn({
         app: this.app,

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -50,4 +50,42 @@ describe('test/lifecycle.test.ts', () => {
       'app_beforeClose',
     ]);
   });
+
+  it('should not trigger lifecyle multi times', async () => {
+    const appWithLifeCyclePath = path.resolve(__dirname, './fixtures/app_with_lifecycle');
+    const app = await createApp(appWithLifeCyclePath);
+    const lifecycleList = app.container.get(LifecycleList).lifecycleList;
+    await Promise.all([
+      app.run(),
+      app.run(),
+      app.run(),
+    ]);
+
+    await Promise.all([
+      app.close(),
+      app.close(),
+      app.close(),
+    ]);
+
+    assert.deepStrictEqual(lifecycleList, [
+      'pluginA_configWillLoad',
+      'pluginB_configWillLoad',
+      'app_configWillLoad',
+      'pluginA_configDidLoad',
+      'pluginB_configDidLoad',
+      'app_configDidLoad',
+      'pluginA_didLoad',
+      'pluginB_didLoad',
+      'app_didLoad',
+      'pluginA_willReady',
+      'pluginB_willReady',
+      'app_willReady',
+      'pluginA_didReady',
+      'pluginB_didReady',
+      'app_didReady',
+      'pluginA_beforeClose',
+      'pluginB_beforeClose',
+      'app_beforeClose',
+    ]);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

生命周期的 hooks 应该只执行一次。

> 举例：使用 ts-node 跑 artus 应用，ctrl + c 的时候，SIGINT 触发两次会触发两次 `beforeClose`
