### PR TITLE
chore: pnpm 6.32.3 build failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "koa": "^2.13.4",
     "reflect-metadata": "^0.1.13",
     "ts-jest": "^27.1.3",
+    "tslib": "^2.4.0",
     "typescript": "^4.7.2"
   },
   "dependencies": {


### PR DESCRIPTION
pnpm version: 6.32.3

```
tsc -p ./tsconfig.build.json

src/exception/handler.ts:5:1 - error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.

5 @Injectable()
  ~~~~~~~~~~~~~


Found 1 error in src/exception/handler.ts:5

 ELIFECYCLE  Command failed with exit code 2.
```