### PR TITLE
feat: support inject named export

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
-    "test": "jest --testTimeout=15000",
+    "test": "jest --coverage --detectOpenHandles --testTimeout=15000",
     "ci": "npm run lint && npm run test",
     "lint:fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
-    "test": "jest",
+    "test": "jest --testTimeout=15000",
     "ci": "npm run lint && npm run test",
     "lint:fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
-    "test": "jest --coverage --detectOpenHandles",
+    "test": "jest",
     "ci": "npm run lint && npm run test",
     "lint:fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts"

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -14,15 +14,21 @@ export enum ArtusInjectEnum {
   Trigger = 'artus#trigger',
 }
 
-export const ARTUS_EXCEPTION_DEFAULT_LOCALE = 'en';
-
-export const ARTUS_SERVER_ENV = 'ARTUS_SERVER_ENV';
-
 export enum ARTUS_DEFAULT_CONFIG_ENV {
   DEV = 'development',
   PROD = 'production',
   DEFAULT = 'default',
 }
+
+export enum ScanPolicy {
+  NamedExport = 'named_export',
+  DefaultExport = 'default_export',
+  All = "all",
+}
+
+export const ARTUS_EXCEPTION_DEFAULT_LOCALE = 'en';
+
+export const ARTUS_SERVER_ENV = 'ARTUS_SERVER_ENV';
 
 export const HOOK_NAME_META_PREFIX = 'hookName:';
 export const HOOK_FILE_LOADER = 'appHook:fileLoader';

--- a/src/loader/factory.ts
+++ b/src/loader/factory.ts
@@ -123,7 +123,7 @@ export class LoaderFactory {
 
     // require file for find loader
     const allExport = await compatibleRequire(path.join(root, filename), true);
-    const names = [];
+    const names: string[] = [];
     const loaders = Array.from(new Set(Object.entries(allExport)
       .map(([name, targetClazz]) => {
         if (!isClass(targetClazz)) {

--- a/src/loader/factory.ts
+++ b/src/loader/factory.ts
@@ -93,7 +93,7 @@ export class LoaderFactory {
   }
 
   async findLoader(opts: LoaderFindOptions): Promise<LoaderFindResult | null> {
-    const loaderName = await this.findLoaderName(opts);
+    const { loader: loaderName } = await this.findLoaderName(opts);
     if (!loaderName) {
       return null;
     }
@@ -111,10 +111,10 @@ export class LoaderFactory {
     return result;
   }
 
-  async findLoaderName(opts: LoaderFindOptions): Promise<string | null> {
+  async findLoaderName(opts: LoaderFindOptions): Promise<{ loader: string | null, names: string[] }> {
     for (const [loaderName, LoaderClazz] of LoaderFactory.loaderClazzMap.entries()) {
       if (await LoaderClazz.is?.(opts)) {
-        return loaderName;
+        return { loader: loaderName, names: [] };
       }
     }
     const { root, filename } = opts;
@@ -149,7 +149,6 @@ export class LoaderFactory {
       throw new Error(`Not support multiple loaders for ${path.join(root, filename)}`);
     }
 
-    console.log(12333, loaders, names);
-    return loaders[0] ?? null;
+    return { loader: loaders[0] ?? null, names };
   }
 }

--- a/src/loader/impl/module.ts
+++ b/src/loader/impl/module.ts
@@ -14,9 +14,9 @@ class ModuleLoader implements Loader {
 
   async load(item: ManifestItem) {
     const origin = await compatibleRequire(item.path, true);
-    item._loaderState = Object.assign({ names: ['default'] }, item._loaderState);
-    const { _loaderState: state } = item as { _loaderState: { names: string[] } };
-    for (const name of state.names) {
+    item._loaderState = Object.assign({ exportNames: ['default'] }, item._loaderState);
+    const { _loaderState: state } = item as { _loaderState: { exportNames: string[] } };
+    for (const name of state.exportNames) {
       const moduleClazz = origin[name];
       const opts: Partial<InjectableDefinition> = {
         path: item.path,

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -21,7 +21,7 @@ interface LoaderFindOptions {
   root: string;
   baseDir: string;
   configDir: string;
-  policy: ScanPolicy;
+  policy?: ScanPolicy;
 }
 
 interface LoaderFindResult {

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -1,4 +1,5 @@
 import { Container } from '@artus/injection';
+import { ScanPolicy } from '../constant';
 
 interface Manifest {
   items: ManifestItem[];
@@ -20,6 +21,7 @@ interface LoaderFindOptions {
   root: string;
   baseDir: string;
   configDir: string;
+  policy: ScanPolicy;
 }
 
 interface LoaderFindResult {

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -171,7 +171,7 @@ export class Scanner {
       if (ScanUtils.isExclude(filename, extname, this.options.exclude, this.options.extensions)) {
         return null;
       }
-      let loader = await loaderFactory.findLoaderName({
+      let { loader } = await loaderFactory.findLoaderName({
         filename,
         baseDir,
         root,

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_EXCLUDES,
   DEFAULT_LOADER_LIST_WITH_ORDER,
   LOADER_NAME_META,
+  ScanPolicy,
 } from '../constant';
 import { LoaderFactory, Manifest, ManifestItem } from '../loader';
 import { ScannerOptions, WalkOptions } from './types';
@@ -37,6 +38,7 @@ export class Scanner {
       useRelativePath: true,
       configDir: DEFAULT_CONFIG_DIR,
       loaderListGenerator: (defaultLoaderList: string[]) => defaultLoaderList,
+      policy: ScanPolicy.All,
       ...options,
       exclude: DEFAULT_EXCLUDES.concat(options.exclude ?? []),
       extensions: [...new Set(this.moduleExtensions.concat(options.extensions ?? []))],
@@ -174,6 +176,7 @@ export class Scanner {
         baseDir,
         root,
         configDir,
+        policy: this.options.policy,
       });
       if (loader === 'framework-config') {
         // SEEME: framework-config is a special loader, cannot be used when scan, need refactor later
@@ -242,6 +245,7 @@ export class Scanner {
       extensions: this.options.extensions,
       exclude: this.options.exclude,
       configDir: this.options.configDir,
+      policy: this.options.policy,
     };
 
     if (source === 'plugin') {

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -2,6 +2,7 @@ import { BaseLoader, ManifestItem } from "../loader";
 import { FrameworkConfig } from "../framework";
 import { PluginConfigItem } from "../plugin/types";
 import { Application } from "../types";
+import { ScanPolicy } from "../constant";
 
 export interface ScannerOptions {
   appName: string;
@@ -10,6 +11,7 @@ export interface ScannerOptions {
   useRelativePath: boolean;
   exclude: string[];
   configDir: string;
+  policy: ScanPolicy;
   envs?: string[];
   framework?: FrameworkConfig;
   plugin?: Record<string, Partial<PluginConfigItem>>;
@@ -21,6 +23,7 @@ export interface WalkOptions {
   source: string;
   baseDir: string;
   configDir: string;
+  policy: ScanPolicy;
   extensions: string[];
   exclude: string[];
   itemMap: Map<string, ManifestItem[]>;

--- a/src/scanner/utils.ts
+++ b/src/scanner/utils.ts
@@ -57,6 +57,7 @@ export class ScanUtils {
           root,
           baseDir,
           configDir,
+          policy: options.policy,
         });
         if (!loaderFindResult) {
           continue;

--- a/src/utils/compatible_require.ts
+++ b/src/utils/compatible_require.ts
@@ -4,10 +4,10 @@ import assert from 'assert';
  * compatible esModule require
  * @param path
  */
-export default async function compatibleRequire(path: string): Promise<any> {
+export default async function compatibleRequire(path: string, origin = false): Promise<any> {
   const requiredModule = await import(path);
 
   assert(requiredModule, `module '${path}' exports is undefined`);
 
-  return requiredModule.default || requiredModule;
+  return origin ? requiredModule : (requiredModule.default || requiredModule);
 }

--- a/test/fixtures/app_koa_with_ts/src/koa_app.ts
+++ b/test/fixtures/app_koa_with_ts/src/koa_app.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@artus/injection';
+import { Injectable, ScopeEnum } from '@artus/injection';
 import Koa from 'koa';
 
-@Injectable()
-export default class KoaApplication extends Koa {}
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
+export default class KoaApplication extends Koa { }

--- a/test/fixtures/app_with_lifecycle/lifecyclelist.ts
+++ b/test/fixtures/app_with_lifecycle/lifecyclelist.ts
@@ -1,6 +1,8 @@
-import { Injectable } from '../../../src';
+import { Injectable, ScopeEnum } from '../../../src';
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class LifecycleList {
   lifecycleList: string[] = [];
 

--- a/test/fixtures/application_specific/src/index.ts
+++ b/test/fixtures/application_specific/src/index.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 import { Manifest, ArtusApplication, ArtusInjectEnum } from "../../../../src";
 import { AbstractBar } from '../../frameworks/bar/src';
-import { Inject, Injectable } from "@artus/injection";
+import { Inject, Injectable, ScopeEnum } from "@artus/injection";
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class MyArtusApplication {
   @Inject('ABSTRACT_BAR')
   private bar: AbstractBar;

--- a/test/fixtures/application_specific/src/plugins/artus_plugin_mysql_ob/src/client.ts
+++ b/test/fixtures/application_specific/src/plugins/artus_plugin_mysql_ob/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface MysqlConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface MysqlConfig {
 
 @Injectable({
   id: 'ARTUS_MYSQL',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/application_specific/src/plugins/artus_plugin_mysql_rds/src/client.ts
+++ b/test/fixtures/application_specific/src/plugins/artus_plugin_mysql_rds/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface MysqlConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface MysqlConfig {
 
 @Injectable({
   id: 'ARTUS_MYSQL',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/application_specific/src/plugins/artus_plugin_redis/src/client.ts
+++ b/test/fixtures/application_specific/src/plugins/artus_plugin_redis/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface RedisConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface RedisConfig {
 
 @Injectable({
   id: 'ARTUS_REDIS',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/artus_application/src/index.ts
+++ b/test/fixtures/artus_application/src/index.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 import { Manifest, ArtusApplication, ArtusInjectEnum } from "../../../../src";
 import { AbstractBar } from '../../frameworks/bar/src';
-import { Inject, Injectable } from "@artus/injection";
+import { Inject, Injectable, ScopeEnum } from "@artus/injection";
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class MyArtusApplication {
   @Inject('ABSTRACT_BAR')
   private bar: AbstractBar;

--- a/test/fixtures/artus_application/src/plugins/artus_plugin_mysql_ob/src/client.ts
+++ b/test/fixtures/artus_application/src/plugins/artus_plugin_mysql_ob/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface MysqlConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface MysqlConfig {
 
 @Injectable({
   id: 'ARTUS_MYSQL',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/artus_application/src/plugins/artus_plugin_mysql_rds/src/client.ts
+++ b/test/fixtures/artus_application/src/plugins/artus_plugin_mysql_rds/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface MysqlConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface MysqlConfig {
 
 @Injectable({
   id: 'ARTUS_MYSQL',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/artus_application/src/plugins/artus_plugin_redis/src/client.ts
+++ b/test/fixtures/artus_application/src/plugins/artus_plugin_redis/src/client.ts
@@ -1,11 +1,12 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface RedisConfig {
-  clientName: string
+  clientName: string,
 }
 
 @Injectable({
   id: 'ARTUS_REDIS',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/custom_instance/custom.ts
+++ b/test/fixtures/custom_instance/custom.ts
@@ -1,6 +1,8 @@
-import { Injectable } from "../../../src/index";
+import { Injectable, ScopeEnum } from "../../../src/index";
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class Custom {
   private name: string;
 

--- a/test/fixtures/frameworks/bar/src/index.ts
+++ b/test/fixtures/frameworks/bar/src/index.ts
@@ -1,9 +1,12 @@
-import { Inject, Injectable } from "@artus/injection";
+import { Inject, Injectable, ScopeEnum } from "@artus/injection";
 import { AbstractFoo } from "../../abstract/foo";
 
 export interface AbstractBar extends AbstractFoo { }
 
-@Injectable({ id: 'ABSTRACT_BAR' })
+@Injectable({
+  id: 'ABSTRACT_BAR',
+  scope: ScopeEnum.SINGLETON,
+})
 export default class FrameworkBar implements AbstractBar {
   @Inject('ABSTRACT_FOO')
   private foo: AbstractFoo;

--- a/test/fixtures/frameworks/bar/src/index.ts
+++ b/test/fixtures/frameworks/bar/src/index.ts
@@ -7,7 +7,7 @@ export interface AbstractBar extends AbstractFoo { }
   id: 'ABSTRACT_BAR',
   scope: ScopeEnum.SINGLETON,
 })
-export default class FrameworkBar implements AbstractBar {
+export class FrameworkBar implements AbstractBar {
   @Inject('ABSTRACT_FOO')
   private foo: AbstractFoo;
 

--- a/test/fixtures/frameworks/layer/foo/foo1/src/index.ts
+++ b/test/fixtures/frameworks/layer/foo/foo1/src/index.ts
@@ -6,7 +6,7 @@ import { server } from './lifecycle';
   id: 'ABSTRACT_FOO',
   scope: ScopeEnum.SINGLETON,
 })
-export default class FrameworkFoo extends ArtusApplication {
+export class FrameworkFoo extends ArtusApplication {
   isListening(): boolean {
     return server?.listening;
   }

--- a/test/fixtures/frameworks/layer/foo/foo1/src/index.ts
+++ b/test/fixtures/frameworks/layer/foo/foo1/src/index.ts
@@ -1,8 +1,11 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 import { ArtusApplication } from '../../../../../../../src';
 import { server } from './lifecycle';
 
-@Injectable({ id: 'ABSTRACT_FOO' })
+@Injectable({
+  id: 'ABSTRACT_FOO',
+  scope: ScopeEnum.SINGLETON,
+})
 export default class FrameworkFoo extends ArtusApplication {
   isListening(): boolean {
     return server?.listening;

--- a/test/fixtures/frameworks/layer/foo/foo2/node_modules/artus_plugin_hbase/src/client.ts
+++ b/test/fixtures/frameworks/layer/foo/foo2/node_modules/artus_plugin_hbase/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface MysqlConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface MysqlConfig {
 
 @Injectable({
   id: 'ARTUS_HBASE',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/frameworks/layer/foo/foo2/node_modules/artus_plugin_mysql_rds/src/client.ts
+++ b/test/fixtures/frameworks/layer/foo/foo2/node_modules/artus_plugin_mysql_rds/src/client.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 
 export interface MysqlConfig {
   clientName: string
@@ -6,6 +6,7 @@ export interface MysqlConfig {
 
 @Injectable({
   id: 'ARTUS_MYSQL',
+  scope: ScopeEnum.SINGLETON,
 })
 export default class Client {
   private clientName = '';

--- a/test/fixtures/frameworks/layer/foo/foo2/src/index.ts
+++ b/test/fixtures/frameworks/layer/foo/foo2/src/index.ts
@@ -6,7 +6,7 @@ import { server } from './lifecycle';
   id: 'ABSTRACT_FOO',
   scope: ScopeEnum.SINGLETON,
 })
-export default class FrameworkFoo extends ArtusApplication {
+export class FrameworkFoo extends ArtusApplication {
   isListening(): boolean {
     return server?.listening;
   }

--- a/test/fixtures/frameworks/layer/foo/foo2/src/index.ts
+++ b/test/fixtures/frameworks/layer/foo/foo2/src/index.ts
@@ -1,8 +1,11 @@
-import { Injectable } from "@artus/injection";
+import { Injectable, ScopeEnum } from "@artus/injection";
 import { ArtusApplication } from '../../../../../../../src';
 import { server } from './lifecycle';
 
-@Injectable({ id: 'ABSTRACT_FOO' })
+@Injectable({
+  id: 'ABSTRACT_FOO',
+  scope: ScopeEnum.SINGLETON,
+})
 export default class FrameworkFoo extends ArtusApplication {
   isListening(): boolean {
     return server?.listening;

--- a/test/fixtures/logger/src/test_clazz.ts
+++ b/test/fixtures/logger/src/test_clazz.ts
@@ -1,12 +1,14 @@
-import { Inject, Injectable } from '@artus/injection';
+import { Inject, Injectable, ScopeEnum } from '@artus/injection';
 import { ArtusLogger, LoggerLevel } from '../../../../src/logger';
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class TestLoggerClazz {
   @Inject()
   private logger!: ArtusLogger;
 
-  public testLog(level: LoggerLevel, message: string|Error, ...splat: any[]) {
+  public testLog(level: LoggerLevel, message: string | Error, ...splat: any[]) {
     this.logger.log({
       level,
       message,
@@ -30,7 +32,7 @@ export default class TestLoggerClazz {
     this.logger.warn(message, ...args);
   }
 
-  public testError(message: string|Error, ...args: any[]) {
+  public testError(message: string | Error, ...args: any[]) {
     this.logger.error(message, ...args);
   }
 }

--- a/test/fixtures/logger/src/test_custom_clazz.ts
+++ b/test/fixtures/logger/src/test_custom_clazz.ts
@@ -1,7 +1,9 @@
-import { Inject, Injectable } from '@artus/injection';
+import { Inject, Injectable, ScopeEnum } from '@artus/injection';
 import CustomLogger from './custom_logger';
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class TestCustomLoggerClazz {
   @Inject()
   private logger!: CustomLogger;
@@ -10,7 +12,7 @@ export default class TestCustomLoggerClazz {
     this.logger.info(message, ...args);
   }
 
-  public testError(message: string|Error, ...args: any[]) {
+  public testError(message: string | Error, ...args: any[]) {
     this.logger.error(message, ...args);
   }
 }

--- a/test/fixtures/named_export/package.json
+++ b/test/fixtures/named_export/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "named-export"
+}

--- a/test/fixtures/named_export/src/config/config.default.ts
+++ b/test/fixtures/named_export/src/config/config.default.ts
@@ -1,3 +1,3 @@
 export default {
-  key: 'random'
-}
+  key: 'random',
+};

--- a/test/fixtures/named_export/src/config/config.default.ts
+++ b/test/fixtures/named_export/src/config/config.default.ts
@@ -1,0 +1,3 @@
+export default {
+  key: 'random'
+}

--- a/test/fixtures/named_export/src/index.ts
+++ b/test/fixtures/named_export/src/index.ts
@@ -1,0 +1,5 @@
+export * from './mysql';
+
+import Redis from './redis';
+
+export { Redis };

--- a/test/fixtures/named_export/src/mysql.ts
+++ b/test/fixtures/named_export/src/mysql.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "../../../../src";
+
+@Injectable()
+export class Mysql {
+  private name = 'mysql';
+
+  getName() {
+    return this.name;
+  }
+}
+
+export const number = 1;
+
+export const object = { a: 1 };
+
+
+export class Mysql2 {
+  private name = 'mysql2';
+
+  getName() {
+    return this.name;
+  }
+}

--- a/test/fixtures/named_export/src/mysql.ts
+++ b/test/fixtures/named_export/src/mysql.ts
@@ -1,6 +1,8 @@
-import { Injectable } from "../../../../src";
+import { Injectable, ScopeEnum } from "../../../../src";
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export class Mysql {
   private name = 'mysql';
 

--- a/test/fixtures/named_export/src/redis.ts
+++ b/test/fixtures/named_export/src/redis.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "../../../../src";
+
+@Injectable()
+export default class Redis {
+  private name = 'redis';
+
+  getName() {
+    return this.name;
+  }
+}
+
+@Injectable()
+export class Redis2 {
+  private name = 'redis2';
+
+  getName() {
+    return this.name;
+  }
+}

--- a/test/fixtures/named_export/src/redis.ts
+++ b/test/fixtures/named_export/src/redis.ts
@@ -1,6 +1,8 @@
-import { Injectable } from "../../../../src";
+import { Injectable, ScopeEnum } from "../../../../src";
 
-@Injectable()
+@Injectable({
+  scope: ScopeEnum.SINGLETON,
+})
 export default class Redis {
   private name = 'redis';
 

--- a/test/fixtures/named_export/src/redis.ts
+++ b/test/fixtures/named_export/src/redis.ts
@@ -19,3 +19,5 @@ export class Redis2 {
     return this.name;
   }
 }
+
+export { Redis };

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -51,7 +51,7 @@ describe('test/loader.test.ts', () => {
       const container = new Container('testDefault');
       const loaderFactory = LoaderFactory.create(container);
 
-      const loaderName = await loaderFactory.findLoaderName({
+      const { loader: loaderName } = await loaderFactory.findLoaderName({
         filename: 'test_clazz.ts',
         root: path.resolve(__dirname, './fixtures/module_with_custom_loader/src'),
         baseDir: path.resolve(__dirname, './fixtures/module_with_custom_loader/src'),

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -1,70 +1,86 @@
 import 'reflect-metadata';
 import { Scanner } from '../src/scanner';
 import path from 'path';
-// import { LoaderFactory } from '../src';
+import { ScanPolicy , LoaderFactory } from '../src';
 
 
 describe('test/scanner.test.ts', () => {
-  // it('should scan application', async () => {
-  //   const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
-  //   const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app_koa_with_ts'));
-  //   const { default: manifest } = scanResults;
-  //   expect(Object.entries(scanResults).length).toBe(2);
-  //   expect(manifest).toBeDefined();
-  //   expect(manifest.items).toBeDefined();
-  //   // console.log('manifest', manifest);
-  //   expect(manifest.items.length).toBe(10);
-
-  //   expect(manifest.items.find(item => item.filename === 'not_to_be_scanned_file.ts')).toBeFalsy();
-
-  //   expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(0);
-  //   expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
-  //   expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);
-  //   expect(manifest.items.filter(item => item.loader === 'lifecycle-hook-unit').length).toBe(2);
-  //   expect(manifest.items.filter(item => item.loader === 'config').length).toBe(1);
-  //   expect(manifest.items.filter(item => item.loader === 'module').length).toBe(4);
-
-  //   expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
-  //   expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
-  //   expect(manifest.items.filter(item => item.source === 'app').length).toBe(8);
-
-  //   const { dev: devManifest } = scanResults;
-  //   // console.log('devManifest', devManifest);
-  //   expect(devManifest).toBeDefined();
-  //   expect(devManifest.items).toBeDefined();
-  //   expect(devManifest.items.length).toBe(12);
-  //   expect(devManifest.items.filter(item => item.loader === 'config').length).toBe(2);
-  //   expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
-  //   expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
-  // });
-
-  // it('should scan module with custom loader', async () => {
-  //   // TODO: allow scan custom loader
-  //   const { default: TestCustomLoader } = await import('./fixtures/module_with_custom_loader/src/loader/test_custom_loader');
-  //   LoaderFactory.register(TestCustomLoader);
-
-  //   const scanner = new Scanner({
-  //     needWriteFile: false,
-  //     extensions: ['.ts', '.js', '.json'],
-  //     configDir: '.',
-  //     loaderListGenerator: () => [TestCustomLoader],
-  //   });
-  //   const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/module_with_custom_loader'));
-  //   const { default: manifest } = scanResults;
-  //   // console.log('manifest', manifest);
-  //   expect(Object.entries(scanResults).length).toBe(1);
-  //   expect(manifest).toBeDefined();
-  //   expect(manifest.items).toBeDefined();
-  //   expect(Array.isArray(manifest.items)).toBe(true);
-  //   expect(manifest.items.length).toBe(1);
-  //   expect(manifest.items[0]?.loader).toBe('test-custom-loader');
-  // });
-
   it('should scan application', async () => {
+    const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
+    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app_koa_with_ts'));
+    const { default: manifest } = scanResults;
+    expect(Object.entries(scanResults).length).toBe(2);
+    expect(manifest).toBeDefined();
+    expect(manifest.items).toBeDefined();
+    // console.log('manifest', manifest);
+    expect(manifest.items.length).toBe(10);
+
+    expect(manifest.items.find(item => item.filename === 'not_to_be_scanned_file.ts')).toBeFalsy();
+
+    expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(0);
+    expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
+    expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);
+    expect(manifest.items.filter(item => item.loader === 'lifecycle-hook-unit').length).toBe(2);
+    expect(manifest.items.filter(item => item.loader === 'config').length).toBe(1);
+    expect(manifest.items.filter(item => item.loader === 'module').length).toBe(4);
+
+    expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
+    expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
+    expect(manifest.items.filter(item => item.source === 'app').length).toBe(8);
+
+    const { dev: devManifest } = scanResults;
+    // console.log('devManifest', devManifest);
+    expect(devManifest).toBeDefined();
+    expect(devManifest.items).toBeDefined();
+    expect(devManifest.items.length).toBe(12);
+    expect(devManifest.items.filter(item => item.loader === 'config').length).toBe(2);
+    expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
+    expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
+  });
+
+  it('should scan module with custom loader', async () => {
+    // TODO: allow scan custom loader
+    const { default: TestCustomLoader } = await import('./fixtures/module_with_custom_loader/src/loader/test_custom_loader');
+    LoaderFactory.register(TestCustomLoader);
+
+    const scanner = new Scanner({
+      needWriteFile: false,
+      extensions: ['.ts', '.js', '.json'],
+      configDir: '.',
+      loaderListGenerator: () => [TestCustomLoader],
+    });
+    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/module_with_custom_loader'));
+    const { default: manifest } = scanResults;
+    // console.log('manifest', manifest);
+    expect(Object.entries(scanResults).length).toBe(1);
+    expect(manifest).toBeDefined();
+    expect(manifest.items).toBeDefined();
+    expect(Array.isArray(manifest.items)).toBe(true);
+    expect(manifest.items.length).toBe(1);
+    expect(manifest.items[0]?.loader).toBe('test-custom-loader');
+  });
+
+  it('should scan application with all injectable class', async () => {
     const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
     const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/named_export'));
     const { default: manifest } = scanResults;
     expect(manifest.items).toBeDefined();
     expect(manifest.items.length).toBe(5);
+  });
+
+  it('should scan application with named export class', async () => {
+    const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'], policy: ScanPolicy.NamedExport });
+    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/named_export'));
+    const { default: manifest } = scanResults;
+    expect(manifest.items).toBeDefined();
+    expect(manifest.items.length).toBe(5);
+  });
+
+  it('should scan application with default export class', async () => {
+    const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'], policy: ScanPolicy.DefaultExport });
+    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/named_export'));
+    const { default: manifest } = scanResults;
+    expect(manifest.items).toBeDefined();
+    expect(manifest.items.length).toBe(3);
   });
 });

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Scanner } from '../src/scanner';
 import path from 'path';
 // import { LoaderFactory } from '../src';
@@ -64,6 +65,6 @@ describe('test/scanner.test.ts', () => {
     const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/named_export'));
     const { default: manifest } = scanResults;
     expect(manifest.items).toBeDefined();
-    expect(manifest.items.length).toBe(4);
+    expect(manifest.items.length).toBe(5);
   });
 });

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -1,61 +1,69 @@
 import { Scanner } from '../src/scanner';
 import path from 'path';
-import { LoaderFactory } from '../src';
+// import { LoaderFactory } from '../src';
 
 
 describe('test/scanner.test.ts', () => {
+  // it('should scan application', async () => {
+  //   const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
+  //   const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app_koa_with_ts'));
+  //   const { default: manifest } = scanResults;
+  //   expect(Object.entries(scanResults).length).toBe(2);
+  //   expect(manifest).toBeDefined();
+  //   expect(manifest.items).toBeDefined();
+  //   // console.log('manifest', manifest);
+  //   expect(manifest.items.length).toBe(10);
+
+  //   expect(manifest.items.find(item => item.filename === 'not_to_be_scanned_file.ts')).toBeFalsy();
+
+  //   expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(0);
+  //   expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
+  //   expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);
+  //   expect(manifest.items.filter(item => item.loader === 'lifecycle-hook-unit').length).toBe(2);
+  //   expect(manifest.items.filter(item => item.loader === 'config').length).toBe(1);
+  //   expect(manifest.items.filter(item => item.loader === 'module').length).toBe(4);
+
+  //   expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
+  //   expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
+  //   expect(manifest.items.filter(item => item.source === 'app').length).toBe(8);
+
+  //   const { dev: devManifest } = scanResults;
+  //   // console.log('devManifest', devManifest);
+  //   expect(devManifest).toBeDefined();
+  //   expect(devManifest.items).toBeDefined();
+  //   expect(devManifest.items.length).toBe(12);
+  //   expect(devManifest.items.filter(item => item.loader === 'config').length).toBe(2);
+  //   expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
+  //   expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
+  // });
+
+  // it('should scan module with custom loader', async () => {
+  //   // TODO: allow scan custom loader
+  //   const { default: TestCustomLoader } = await import('./fixtures/module_with_custom_loader/src/loader/test_custom_loader');
+  //   LoaderFactory.register(TestCustomLoader);
+
+  //   const scanner = new Scanner({
+  //     needWriteFile: false,
+  //     extensions: ['.ts', '.js', '.json'],
+  //     configDir: '.',
+  //     loaderListGenerator: () => [TestCustomLoader],
+  //   });
+  //   const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/module_with_custom_loader'));
+  //   const { default: manifest } = scanResults;
+  //   // console.log('manifest', manifest);
+  //   expect(Object.entries(scanResults).length).toBe(1);
+  //   expect(manifest).toBeDefined();
+  //   expect(manifest.items).toBeDefined();
+  //   expect(Array.isArray(manifest.items)).toBe(true);
+  //   expect(manifest.items.length).toBe(1);
+  //   expect(manifest.items[0]?.loader).toBe('test-custom-loader');
+  // });
+
   it('should scan application', async () => {
     const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
-    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app_koa_with_ts'));
+    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/named_export'));
     const { default: manifest } = scanResults;
-    expect(Object.entries(scanResults).length).toBe(2);
-    expect(manifest).toBeDefined();
     expect(manifest.items).toBeDefined();
-    // console.log('manifest', manifest);
-    expect(manifest.items.length).toBe(10);
-
-    expect(manifest.items.find(item => item.filename === 'not_to_be_scanned_file.ts')).toBeFalsy();
-
-    expect(manifest.items.filter(item => item.loader === 'plugin-config').length).toBe(0);
-    expect(manifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(1);
-    expect(manifest.items.filter(item => item.loader === 'exception').length).toBe(1);
-    expect(manifest.items.filter(item => item.loader === 'lifecycle-hook-unit').length).toBe(2);
-    expect(manifest.items.filter(item => item.loader === 'config').length).toBe(1);
-    expect(manifest.items.filter(item => item.loader === 'module').length).toBe(4);
-
-    expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
-    expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
-    expect(manifest.items.filter(item => item.source === 'app').length).toBe(8);
-
-    const { dev: devManifest } = scanResults;
-    // console.log('devManifest', devManifest);
-    expect(devManifest).toBeDefined();
-    expect(devManifest.items).toBeDefined();
-    expect(devManifest.items.length).toBe(12);
-    expect(devManifest.items.filter(item => item.loader === 'config').length).toBe(2);
-    expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
-    expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
-  });
-
-  it('should scan module with custom loader', async () => {
-    // TODO: allow scan custom loader
-    const { default: TestCustomLoader } = await import('./fixtures/module_with_custom_loader/src/loader/test_custom_loader');
-    LoaderFactory.register(TestCustomLoader);
-
-    const scanner = new Scanner({
-      needWriteFile: false,
-      extensions: ['.ts', '.js', '.json'],
-      configDir: '.',
-      loaderListGenerator: () => [TestCustomLoader],
-    });
-    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/module_with_custom_loader'));
-    const { default: manifest } = scanResults;
-    // console.log('manifest', manifest);
-    expect(Object.entries(scanResults).length).toBe(1);
-    expect(manifest).toBeDefined();
-    expect(manifest.items).toBeDefined();
-    expect(Array.isArray(manifest.items)).toBe(true);
-    expect(manifest.items.length).toBe(1);
-    expect(manifest.items[0]?.loader).toBe('test-custom-loader');
+    expect(manifest.items.length).toBe(4);
   });
 });


### PR DESCRIPTION
此 PR 旨在支持具名导出，Scanner 中提供参数 `policy` 控制扫描期行为：
* `ScanPolicy.All`：默认值，会扫描全部的默认导出 & 具名导出
* `ScanPolicy.NamedExport`：只扫描具名导出，忽略默认导出
* `ScanPolicy.DefaultExport`：只扫描默认导出，忽略具名导出

当前实现中，横跨扫描期和启动期的状态由 `ManifestItem._loaderState` 保留字段处理，这个可以考虑转换为公有属性透出给用户处理两个阶段的状态保存。

注意可能的 break：如果想要完全兼容 master 的逻辑，默认值可以考虑更换为 `ScanPolicy.DefaultExport`，这一点需要确认下

close https://github.com/artusjs/core/issues/163