### PR TITLE
fix: lint error

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "reflect-metadata": "^0.1.13",
     "ts-jest": "^27.1.3",
     "tslib": "^2.4.0",
-    "typescript": "^4.7.2"
+    "typescript": "~4.7.2"
   },
   "dependencies": {
     "@artus/injection": "^0.4.1",


### PR DESCRIPTION
`@artus/eslint-config-artus` 依赖的 `@typescript-eslint/typescript-estree` 最新版本 5.35.1 无法支持最新的 `typescript@4.8.2`：

```bash
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.8.0

YOUR TYPESCRIPT VERSION: 4.8.2

Please only submit bug reports when using the officially supported version.

=============
```

导致 lint 报错，并使得 CI 全部挂掉：https://github.com/artusjs/core/actions/runs/2930918347

考虑临时通过 sermver 锁定到 4.7.x 来解决，观察后续的依赖更新状态再解锁。

## 延伸问题

typescript 的版本并不会遵循 sermver 规则，minor & patch 版本的更新产生的 break 需要在 spec 中约定一个明确的处理方式，并透出给用户。