### PR TITLE
feat(scanner): add parsed pluginConfig to manifest

### DIFF
--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -1,8 +1,10 @@
 import { Container } from '@artus/injection';
 import { ScanPolicy } from '../constant';
+import { PluginConfigItem } from '../plugin/types';
 
 interface Manifest {
   items: ManifestItem[];
+  pluginConfig?: Record<string, PluginConfigItem>;
   relative?: boolean;
 }
 

--- a/src/scanner/scan.ts
+++ b/src/scanner/scan.ts
@@ -129,9 +129,18 @@ export class Scanner {
     // 4. scan all file in app
     await this.walk(root, this.formatWalkOptions('app', root, ''));
 
+    const relative = this.options.useRelativePath;
+    if (relative) {
+      for (const [pluginName, pluginConfigItem] of Object.entries(pluginConfig)) {
+        if (pluginConfigItem.path) {
+          pluginConfig[pluginName].path = path.relative(root, pluginConfigItem.path);
+        }
+      }
+    }
     const result: Manifest = {
-      items: this.getItemsFromMap(this.options.useRelativePath, root, env),
-      relative: this.options.useRelativePath,
+      pluginConfig,
+      items: this.getItemsFromMap(relative, root, env),
+      relative,
     };
     return result;
   }

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -27,6 +27,11 @@ describe('test/scanner.test.ts', () => {
     expect(manifest.items.filter(item => item.unitName === 'redis').length).toBe(2);
     expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
     expect(manifest.items.filter(item => item.source === 'app').length).toBe(8);
+    expect(manifest.pluginConfig).toStrictEqual({
+      redis: { enable: true, path: 'src/redis_plugin' },
+      mysql: { enable: false, path: 'src/mysql_plugin' },
+      testDuplicate: { enable: false, path: '../../../node_modules/@artus/injection/lib' },
+    });
 
     const { dev: devManifest } = scanResults;
     // console.log('devManifest', devManifest);
@@ -36,6 +41,11 @@ describe('test/scanner.test.ts', () => {
     expect(devManifest.items.filter(item => item.loader === 'config').length).toBe(2);
     expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
     expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
+    expect(devManifest.pluginConfig).toStrictEqual({
+      redis: { enable: true, path: 'src/redis_plugin' },
+      mysql: { enable: false, path: 'src/mysql_plugin' },
+      testDuplicate: { enable: true, path: 'src/test_duplicate_plugin' },
+    });
   });
 
   it('should scan module with custom loader', async () => {

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -28,9 +28,9 @@ describe('test/scanner.test.ts', () => {
     expect(manifest.items.filter(item => item.unitName === 'mysql').length).toBe(0);
     expect(manifest.items.filter(item => item.source === 'app').length).toBe(8);
     expect(manifest.pluginConfig).toStrictEqual({
-      redis: { enable: true, path: 'src/redis_plugin' },
-      mysql: { enable: false, path: 'src/mysql_plugin' },
-      testDuplicate: { enable: false, path: '../../../node_modules/@artus/injection/lib' },
+      redis: { enable: true, path: path.join('src', 'redis_plugin') },
+      mysql: { enable: false, path: path.join('src', 'mysql_plugin') },
+      testDuplicate: { enable: false, path: path.join('..', '..', '..', 'node_modules', '@artus', 'injection', 'lib') },
     });
 
     const { dev: devManifest } = scanResults;
@@ -42,9 +42,9 @@ describe('test/scanner.test.ts', () => {
     expect(devManifest.items.filter(item => item.loader === 'plugin-meta').length).toBe(2);
     expect(devManifest.items.find(item => item.unitName === 'testDuplicate')).toBeDefined();
     expect(devManifest.pluginConfig).toStrictEqual({
-      redis: { enable: true, path: 'src/redis_plugin' },
-      mysql: { enable: false, path: 'src/mysql_plugin' },
-      testDuplicate: { enable: true, path: 'src/test_duplicate_plugin' },
+      redis: { enable: true, path: path.join('src', 'redis_plugin') },
+      mysql: { enable: false, path: path.join('src', 'mysql_plugin') },
+      testDuplicate: { enable: true, path: path.join('src', 'test_duplicate_plugin') },
     });
   });
 


### PR DESCRIPTION
本 PR 向 Manifest 类型定义和 Scanner.scan 方法逻辑中增加了 `pluginConfig` 字段，值为经解析后的插件配置，用于：

- 运行时数据上报 / 构建时依赖分析
- 多 Env 场景下的运行时 Manifest 合并逻辑中，作为 plugin 启用判断的辅助数据