### PR TITLE
fix: correct test dir

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -33,7 +33,7 @@ export const HOOK_FILE_LOADER = 'appHook:fileLoader';
 export const HOOK_CONFIG_HANDLE = 'appHook:configHandle::';
 
 export const DEFAULT_EXCLUDES = [
-  'test/',
+  'test',
   'node_modules',
   '.*',
   'tsconfig*.json',

--- a/test/fixtures/app_with_lifecycle/test/throw.ts
+++ b/test/fixtures/app_with_lifecycle/test/throw.ts
@@ -1,0 +1,1 @@
+throw new Error('should not scan me');

--- a/test/scanner.test.ts
+++ b/test/scanner.test.ts
@@ -49,6 +49,14 @@ describe('test/scanner.test.ts', () => {
     });
   });
 
+  it('should not scan test dir', async () => {
+    const scanner = new Scanner({ needWriteFile: false, extensions: ['.ts', '.js', '.json'] });
+    const scanResults = await scanner.scan(path.resolve(__dirname, './fixtures/app_with_lifecycle'));
+    const { default: manifest } = scanResults;
+    expect(manifest.items).toBeDefined();
+    expect(manifest.items.find(item => item.filename === 'throw.ts')).toBeUndefined();
+  });
+
   it('should scan module with custom loader', async () => {
     // TODO: allow scan custom loader
     const { default: TestCustomLoader } = await import('./fixtures/module_with_custom_loader/src/loader/test_custom_loader');


### PR DESCRIPTION
将原来配置的 `test/` 改成 `test`，因为匹配的都是文件夹名和文件名，有 `/` 会导致匹配不到 test 目录。