### PR TITLE
fix(plugin): prevent require.resolve paths arguments undefined

### DIFF
--- a/src/plugin/factory.ts
+++ b/src/plugin/factory.ts
@@ -46,7 +46,8 @@ export class PluginFactory {
             `Plugin ${pluginName} config can't have both package and path at ${manifestItem?.path ?? 'UNKNOWN_PATH'}`,
           );
         }
-        pluginConfigItem.path = getPackagePath(pluginConfigItem.package, [loaderState?.baseDir]);
+        const requirePaths = loaderState?.baseDir ? [loaderState.baseDir] : undefined;
+        pluginConfigItem.path = getPackagePath(pluginConfigItem.package, requirePaths);
         delete pluginConfigItem.package;
       } else if (pluginConfigItem.path && await exists(path.resolve(pluginConfigItem.path, 'package.json'))) {
         // plugin path is a npm package, need resolve main file


### PR DESCRIPTION
related #229 

1.0.4 版本可能造成使用预先生成的 manifest 文件时，因为缺少扫描器补入的 baseDir（对 package 字段意义不大）造成 require.resolve 失败

![image](https://user-images.githubusercontent.com/2758317/220344974-69fe5e0d-6b91-49e2-bb72-27c44d211636.png)

代码很早之前就在，之前未触发的主要原因是：
- Scanner 之前基于避免非必要合并的考虑，剔除了 `plugin-config` loader 的全部 item，所以确实 `loaderState.baseDir` 的 item 不会进入运行时的 loader
- 重构期间为了对齐所有 config 的合并逻辑，移除了剔除 item 的代码
