### PR TITLE
deps: add reflect-metadata to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "deepmerge": "^4.2.2",
     "minimatch": "^5.0.1"
   },
+  "peerDependencies": {
+    "reflect-metadata": "^0.1.13"
+  },
   "ci": {
     "version": "16, 18"
   }


### PR DESCRIPTION
```
Error: Cannot find module 'reflect-metadata'
Require stack:
/node_modules/.store/@artus+core@1.0.5/node_modules/@artus/core/lib/application.js
/node_modules/.store/@artus+core@1.0.5/node_modules/@artus/core/lib/index.js
/node_modules/.store/@artus-cli+artus-cli@0.2.3/node_modules/@artus-cli/artus-cli/dist/index.js
/node_modules/.store/egg-bin@6.1.2/node_modules/egg-bin/dist/bin/cli.js
```
