### PR TITLE
refactor: support load manifest version 2

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -3,14 +3,14 @@ import { Container } from '@artus/injection';
 import { ArtusInjectEnum } from './constant';
 import { ArtusStdError } from './exception';
 import { HookFunction, LifecycleManager } from './lifecycle';
-import { LoaderFactory, Manifest } from './loader';
+import { LoaderFactory, Manifest, ManifestV2 } from './loader';
 import { Application, ApplicationInitOptions } from './types';
 import Trigger from './trigger';
 import ConfigurationHandler from './configuration';
 import { Logger, LoggerType } from './logger';
 
 export class ArtusApplication implements Application {
-  public manifest?: Manifest;
+  public manifest?: Manifest | ManifestV2;
   public container: Container;
 
   protected lifecycleManager: LifecycleManager;
@@ -19,7 +19,7 @@ export class ArtusApplication implements Application {
   constructor(opts?: ApplicationInitOptions) {
     this.container = new Container(opts?.containerName ?? ArtusInjectEnum.DefaultContainerName);
     this.lifecycleManager = new LifecycleManager(this, this.container);
-    this.loaderFactory = LoaderFactory.create(this.container);
+    this.loaderFactory = new LoaderFactory(this.container);
 
     this.addLoaderListener();
     this.loadDefaultClass();
@@ -59,7 +59,7 @@ export class ArtusApplication implements Application {
     this.container.set({ type: Trigger });
   }
 
-  async load(manifest: Manifest, root: string = process.cwd()) {
+  async load(manifest: Manifest | ManifestV2, root: string = process.cwd()) {
     // Load user manifest
     this.manifest = manifest;
 

--- a/src/loader/helper.ts
+++ b/src/loader/helper.ts
@@ -1,0 +1,85 @@
+import path from 'path';
+import { isInjectable } from '@artus/injection';
+import { LoaderFactory } from './factory';
+import {
+  LoaderFindOptions,
+  LoaderFindResult,
+} from './types';
+import { ScanPolicy, HOOK_FILE_LOADER, DEFAULT_LOADER } from '../constant';
+import compatibleRequire from '../utils/compatible_require';
+import { isClass } from '../utils/is';
+
+const findLoaderName = async (opts: LoaderFindOptions): Promise<{ loader: string | null, exportNames: string[] }> => {
+  // Use Loader.is to find loader
+  for (const [loaderName, LoaderClazz] of LoaderFactory.loaderClazzMap.entries()) {
+    if (await LoaderClazz.is?.(opts)) {
+      return { loader: loaderName, exportNames: [] };
+    }
+  }
+  const { root, filename, policy = ScanPolicy.All } = opts;
+
+  // require file for find loader
+  const allExport = await compatibleRequire(path.join(root, filename), true);
+  const exportNames: string[] = [];
+
+  let loaders = Object.entries(allExport)
+    .map(([name, targetClazz]) => {
+      if (!isClass(targetClazz)) {
+        // The file is not export with default class
+        return null;
+      }
+
+      if (policy === ScanPolicy.NamedExport && name === 'default') {
+        return null;
+      }
+
+      if (policy === ScanPolicy.DefaultExport && name !== 'default') {
+        return null;
+      }
+
+      // get loader from reflect metadata
+      const loaderMd = Reflect.getMetadata(HOOK_FILE_LOADER, targetClazz);
+      if (loaderMd?.loader) {
+        exportNames.push(name);
+        return loaderMd.loader;
+      }
+
+      // default loder with @Injectable
+      const injectableMd = isInjectable(targetClazz);
+      if (injectableMd) {
+        exportNames.push(name);
+        return DEFAULT_LOADER;
+      }
+    })
+    .filter(v => v);
+
+  loaders = Array.from(new Set(loaders));
+
+  if (loaders.length > 1) {
+    throw new Error(`Not support multiple loaders for ${path.join(root, filename)}`);
+  }
+
+  return { loader: loaders[0] ?? null, exportNames };
+};
+
+export const findLoader = async (opts: LoaderFindOptions): Promise<LoaderFindResult | null> => {
+  const { loader: loaderName, exportNames } = await findLoaderName(opts);
+
+  if (!loaderName) {
+    return null;
+  }
+
+  const loaderClazz = LoaderFactory.loaderClazzMap.get(loaderName);
+  if (!loaderClazz) {
+    throw new Error(`Cannot find loader '${loaderName}'`);
+  }
+  const result: LoaderFindResult = {
+    loaderName,
+    loaderState: { exportNames },
+  };
+  if (loaderClazz.onFind) {
+    result.loaderState = await loaderClazz.onFind(opts);
+  }
+  return result;
+};
+

--- a/src/loader/helper.ts
+++ b/src/loader/helper.ts
@@ -9,7 +9,7 @@ import { ScanPolicy, HOOK_FILE_LOADER, DEFAULT_LOADER } from '../constant';
 import compatibleRequire from '../utils/compatible_require';
 import { isClass } from '../utils/is';
 
-const findLoaderName = async (opts: LoaderFindOptions): Promise<{ loader: string | null, exportNames: string[] }> => {
+export const findLoaderName = async (opts: LoaderFindOptions): Promise<{ loader: string | null, exportNames: string[] }> => {
   // Use Loader.is to find loader
   for (const [loaderName, LoaderClazz] of LoaderFactory.loaderClazzMap.entries()) {
     if (await LoaderClazz.is?.(opts)) {

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -9,6 +9,7 @@ for (const [_, impl] of Object.entries(LoaderImpls)) {
   LoaderFactory.register(impl);
 }
 
+export * from './helper';
 export * from './types';
 
 export {

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -1,6 +1,6 @@
 import { Container } from '@artus/injection';
 import { ScanPolicy } from '../constant';
-import { PluginConfigItem, PluginDependencyItem } from '../plugin/types';
+import { PluginConfigItem, PluginMetadata } from '../plugin/types';
 
 export interface Manifest {
   items: ManifestItem[];
@@ -9,21 +9,21 @@ export interface Manifest {
 }
 export type ManifestEnvMap = Record<string, Manifest>;
 
-export interface ManifestV2PluginConfigItem {
-  enable: boolean;
-  refName: string;
-}
-export type ManifestV2PluginConfig = Record<string, ManifestV2PluginConfigItem>;
+// Key: Env => PluginName => Value: PluginConfigItem
+export type ManifestV2PluginConfig = Record<string, Record<string, PluginConfigItem>>;
+
 export interface ManifestV2RefMapItem {
   packageVersion?: string;
-  dependencies?: PluginDependencyItem[];
+  pluginMetadata?: PluginMetadata;
   items: ManifestItem[];
 }
+// Key: RefName => RefMapItem
+export type ManifestV2RefMap = Record<string, ManifestV2RefMapItem>;
 
 export interface ManifestV2 {
   version: '2';
-  pluginConfig: Record<string, Record<string, ManifestV2PluginConfigItem>>;
-  refMap: Record<string, ManifestV2RefMapItem>;
+  pluginConfig: ManifestV2PluginConfig;
+  refMap: ManifestV2RefMap;
   relative: boolean;
 }
 

--- a/src/plugin/impl.ts
+++ b/src/plugin/impl.ts
@@ -10,7 +10,7 @@ export class Plugin implements PluginType {
   public name: string;
   public enable: boolean;
   public importPath = '';
-  public metadata: Partial<PluginMetadata> = {};
+  public metadata: Partial<PluginMetadata> | null = null;
   public metaFilePath = '';
 
   private logger?: LoggerType;
@@ -26,10 +26,13 @@ export class Plugin implements PluginType {
         }
         importPath = getPackagePath(configItem.package);
       }
-      if (!importPath) {
+      if (!importPath && !configItem.refName) {
         throw new Error(`Plugin ${name} need have path or package field`);
       }
       this.importPath = importPath;
+    }
+    if (configItem.metadata) {
+      this.metadata = configItem.metadata;
     }
     this.logger = opts?.logger;
   }
@@ -67,6 +70,10 @@ export class Plugin implements PluginType {
   }
 
   private async checkAndLoadMetadata() {
+    // check metadata from configItem
+    if (this.metadata) {
+      return;
+    }
     // check import path
     if (!await exists(this.importPath)) {
       throw new Error(`load plugin <${this.name}> import path ${this.importPath} is not exists.`);

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -21,6 +21,8 @@ export interface PluginConfigItem {
   enable: boolean;
   path?: string;
   package?: string;
+  refName?: string;
+  metadata?: PluginMetadata;
 }
 
 export type PluginMap = Map<string, PluginType>;

--- a/src/scanner/task.ts
+++ b/src/scanner/task.ts
@@ -1,12 +1,14 @@
 import path from 'path';
 import * as fs from 'fs/promises';
 import { ScanContext, ScanTaskItem, WalkOptions } from './types';
-import { existsAsync, getPackageVersion, getPluginMeta, getPluginRefName, getPluginRefPath, isExclude, isPluginAsync } from './utils';
-import { findLoader, LoaderFactory, ManifestItem, ManifestV2PluginConfig, ManifestV2PluginConfigItem } from '../loader';
-import { PluginConfigItem, PluginDependencyItem } from '../plugin';
+import { existsAsync, getPackageVersion, getPluginRefName, getPluginRefPath, isExclude, isPluginAsync } from './utils';
+import { findLoader, LoaderFactory, ManifestItem, ManifestV2PluginConfig, ManifestV2RefMapItem } from '../loader';
+import { PluginConfigItem, PluginMetadata } from '../plugin';
 import { mergeConfig } from '../loader/utils/merge';
 import { Container } from '@artus/injection';
 import ConfigurationHandler from '../configuration';
+import { loadMetaFile } from '../utils/load_meta_file';
+import { PLUGIN_META_FILENAME } from '../constant';
 
 const walkDir = async (root: string, options: WalkOptions, itemList: ManifestItem[] = []) => {
   const { baseDir, configDir } = options;
@@ -83,9 +85,9 @@ export const handlePluginConfig = async (configItemList: ManifestItem[], root: s
   container.set({
     type: ConfigurationHandler,
   });
-  const loaderFactory = LoaderFactory.create(container);
+  const loaderFactory = new LoaderFactory(container);
   await loaderFactory.loadItemList(configItemList);
-  const pluginConfigEnvMap: Record<string, ManifestV2PluginConfig> = {};
+  const pluginConfigEnvMap: ManifestV2PluginConfig = {};
   for (const [env, configObj] of loaderFactory.configurationHandler.configStore) {
     if (configObj?.plugin) {
       pluginConfigEnvMap[env] = {};
@@ -94,7 +96,7 @@ export const handlePluginConfig = async (configItemList: ManifestItem[], root: s
         pluginConfigEnvMap[env][pluginName] = {
           enable: configObj.plugin.enable,
           refName,
-        } as ManifestV2PluginConfigItem;
+        } as PluginConfigItem;
         if (refName && !refNameSet.has(refName) && !scanCtx.refMap[refName]) {
           // Generate and push scan task
           scanCtx.taskQueue.push({
@@ -107,7 +109,7 @@ export const handlePluginConfig = async (configItemList: ManifestItem[], root: s
       }
     }
   }
-  scanCtx.pluginConfigMap = mergeConfig(pluginConfigEnvMap, scanCtx.pluginConfigMap) as Record<string, ManifestV2PluginConfig>;
+  scanCtx.pluginConfigMap = mergeConfig(pluginConfigEnvMap, scanCtx.pluginConfigMap) as ManifestV2PluginConfig;
 };
 
 
@@ -135,26 +137,30 @@ export const runTask = async (taskItem: ScanTaskItem, scanCtx: ScanContext) => {
     extensions: scanCtx.options.extensions,
     policy: scanCtx.options.policy,
   };
-  let dependencies: PluginDependencyItem[];
+  const refItem: ManifestV2RefMapItem = {
+    packageVersion: await getPackageVersion(basePath),
+    items: [],
+  };
 
   if (await isPluginAsync(basePath)) {
-    const pluginMeta = await getPluginMeta(basePath);
+    const metaFilePath = path.resolve(basePath, PLUGIN_META_FILENAME);
+    const pluginMeta: PluginMetadata = await loadMetaFile(metaFilePath);
     walkOpts.configDir = pluginMeta.configDir || walkOpts.configDir;
     walkOpts.exclude = walkOpts.exclude.concat(pluginMeta.exclude ?? []);
-    dependencies = pluginMeta.dependencies;
+    refItem.pluginMetadata = pluginMeta;
   }
 
-  const itemList = await walkDir(basePath, walkOpts);
-  const configItemList = itemList.filter(item => item.loader === 'config');
+  refItem.items = await walkDir(basePath, walkOpts);
+  const configItemList = refItem.items.filter(item => item.loader === 'config');
   await handlePluginConfig(configItemList, root, basePath, scanCtx);
 
-  scanCtx.refMap[refName] = {
-    packageVersion: await getPackageVersion(basePath),
-    dependencies,
-    items: scanCtx.options.useRelativePath ? itemList.map(item => ({
+  if (scanCtx.options.useRelativePath) {
+    refItem.items = refItem.items.map(item => ({
       ...item,
       path: path.relative(root, item.path),
-    })) : itemList,
-  };
+    }));
+  }
+
+  scanCtx.refMap[refName] = refItem;
 };
 

--- a/src/scanner/task.ts
+++ b/src/scanner/task.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import * as fs from 'fs/promises';
 import { ScanContext, ScanTaskItem, WalkOptions } from './types';
 import { existsAsync, getPackageVersion, getPluginMeta, getPluginRefName, getPluginRefPath, isExclude, isPluginAsync } from './utils';
-import { LoaderFactory, ManifestItem, ManifestV2PluginConfig, ManifestV2PluginConfigItem } from '../loader';
+import { findLoader, LoaderFactory, ManifestItem, ManifestV2PluginConfig, ManifestV2PluginConfigItem } from '../loader';
 import { PluginConfigItem, PluginDependencyItem } from '../plugin';
 import { mergeConfig } from '../loader/utils/merge';
 import { Container } from '@artus/injection';
@@ -45,7 +45,7 @@ const walkDir = async (root: string, options: WalkOptions, itemList: ManifestIte
       }
       const filename = path.basename(realPath);
       const filenameWithoutExt = path.basename(realPath, extname);
-      const loaderFindResult = await LoaderFactory.findLoader({
+      const loaderFindResult = await findLoader({
         filename,
         root,
         baseDir,
@@ -83,7 +83,7 @@ export const handlePluginConfig = async (configItemList: ManifestItem[], root: s
   container.set({
     type: ConfigurationHandler,
   });
-  const loaderFactory = new LoaderFactory(container);
+  const loaderFactory = LoaderFactory.create(container);
   await loaderFactory.loadItemList(configItemList);
   const pluginConfigEnvMap: Record<string, ManifestV2PluginConfig> = {};
   for (const [env, configObj] of loaderFactory.configurationHandler.configStore) {

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -47,7 +47,7 @@ export interface ScanTaskItem {
 
 export interface ScanContext {
   taskQueue: ScanTaskItem[];
-  pluginConfigMap: Record<string, ManifestV2PluginConfig>;
+  pluginConfigMap: ManifestV2PluginConfig;
   refMap: Record<string, ManifestV2RefMapItem>;
   options: ScannerOptions;
 }

--- a/src/scanner/utils.ts
+++ b/src/scanner/utils.ts
@@ -4,7 +4,7 @@ import *  as fs from 'fs/promises';
 import { isMatch } from '../utils';
 import compatibleRequire from '../utils/compatible_require';
 import { PLUGIN_META_FILENAME } from '../constant';
-import { PluginConfigItem, PluginMetadata } from '../plugin';
+import { PluginConfigItem } from '../plugin';
 import { getInlinePackageEntryPath, getPackagePath } from '../plugin/common';
 
 export const getPackageVersion = async (basePath: string): Promise<string | undefined> => {
@@ -40,10 +40,6 @@ export const isExclude = (filename: string, extname: string, exclude: string[], 
 
 export const isPluginAsync = (basePath: string): Promise<boolean> => {
   return existsAsync(path.resolve(basePath, PLUGIN_META_FILENAME));
-};
-
-export const getPluginMeta = (basePath: string): Promise<PluginMetadata> => {
-  return compatibleRequire(path.resolve(basePath, PLUGIN_META_FILENAME));
 };
 
 export const getPluginRefName = (pluginConfigItem: PluginConfigItem, root: string): string | undefined => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Container } from '@artus/injection';
 import { BaseContext } from '@artus/pipeline';
 import { HookFunction } from './lifecycle';
-import { Manifest } from './loader';
+import { Manifest, ManifestV2 } from './loader';
 import { LoggerType } from './logger';
 
 export interface ApplicationLifecycle {
@@ -21,7 +21,7 @@ export interface ApplicationInitOptions {
 export interface Application {
   container: Container;
 
-  manifest?: Manifest;
+  manifest?: Manifest | ManifestV2;
   config?: Record<string, any>;
 
   // getter

--- a/test/__snapshots__/scanner.test.ts.snap
+++ b/test/__snapshots__/scanner.test.ts.snap
@@ -26,12 +26,10 @@ Object {
   },
   "refMap": Object {
     "@artus/injection": Object {
-      "dependencies": undefined,
       "items": Array [],
       "packageVersion": undefined,
     },
     "_app": Object {
-      "dependencies": undefined,
       "items": Array [
         Object {
           "extname": ".json",
@@ -157,7 +155,6 @@ Object {
       "packageVersion": undefined,
     },
     "src/mysql_plugin": Object {
-      "dependencies": undefined,
       "items": Array [
         Object {
           "extname": ".ts",
@@ -172,9 +169,11 @@ Object {
         },
       ],
       "packageVersion": undefined,
+      "pluginMetadata": Object {
+        "name": "mysql",
+      },
     },
     "src/redis_plugin": Object {
-      "dependencies": undefined,
       "items": Array [
         Object {
           "extname": ".ts",
@@ -189,11 +188,20 @@ Object {
         },
       ],
       "packageVersion": undefined,
+      "pluginMetadata": Object {
+        "exclude": Array [
+          "not_to_be_scanned_dir",
+          "not_to_be_scanned_file.ts",
+        ],
+        "name": "redis",
+      },
     },
     "src/test_duplicate_plugin": Object {
-      "dependencies": undefined,
       "items": Array [],
       "packageVersion": undefined,
+      "pluginMetadata": Object {
+        "name": "testDuplicate",
+      },
     },
   },
   "relative": true,

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import assert from 'assert';
 import path from 'path';
 import { Container } from '@artus/injection';
-import { LoaderFactory } from '../src';
+import { LoaderFactory, findLoaderName } from '../src';
 import Custom from './fixtures/custom_instance/custom';
 import { createApp } from './utils';
 
@@ -11,8 +11,9 @@ describe('test/loader.test.ts', () => {
   describe('module with ts', () => {
     it('should load module testServiceA.ts and testServiceB.ts', async () => {
       const container = new Container('testDefault');
-      const loaderFactory = LoaderFactory.create(container);
+      const loaderFactory = new LoaderFactory(container);
 
+      // Manifest Version 1
       const manifest = require('./fixtures/module_with_ts/src/index').default;
       await loaderFactory.loadManifest(manifest);
       assert((container.get('testServiceA') as any).testMethod() === 'Hello Artus');
@@ -22,7 +23,7 @@ describe('test/loader.test.ts', () => {
   describe('module with js', () => {
     it('should load module testServiceA.js and testServiceB.js', async () => {
       const container = new Container('testDefault');
-      const loaderFactory = LoaderFactory.create(container);
+      const loaderFactory = new LoaderFactory(container);
 
       const manifest = require('./fixtures/module_with_js/src/index');
       await loaderFactory.loadManifest(manifest);
@@ -49,9 +50,9 @@ describe('test/loader.test.ts', () => {
       const { default: manifest } = require('./fixtures/module_with_custom_loader/src/index');
 
       const container = new Container('testDefault');
-      const loaderFactory = LoaderFactory.create(container);
+      const loaderFactory = new LoaderFactory(container);
 
-      const { loader: loaderName } = await loaderFactory.findLoaderName({
+      const { loader: loaderName } = await findLoaderName({
         filename: 'test_clazz.ts',
         root: path.resolve(__dirname, './fixtures/module_with_custom_loader/src'),
         baseDir: path.resolve(__dirname, './fixtures/module_with_custom_loader/src'),
@@ -76,7 +77,7 @@ describe('test/loader.test.ts', () => {
   describe('loader event', () => {
     it('should emit loader event', async () => {
       const container = new Container('testDefault');
-      const loaderFactory = LoaderFactory.create(container);
+      const loaderFactory = new LoaderFactory(container);
       const cb = jest.fn();
       loaderFactory.addLoaderListener('module', {
         before: () => {
@@ -91,7 +92,7 @@ describe('test/loader.test.ts', () => {
 
     it('should remove listener success', async () => {
       const container = new Container('testDefault');
-      const loaderFactory = LoaderFactory.create(container);
+      const loaderFactory = new LoaderFactory(container);
       const cb = jest.fn();
       loaderFactory.addLoaderListener('module', {
         before: () => {
@@ -108,7 +109,7 @@ describe('test/loader.test.ts', () => {
 
     it('should remove listener success with stage', async () => {
       const container = new Container('testDefault');
-      const loaderFactory = LoaderFactory.create(container);
+      const loaderFactory = new LoaderFactory(container);
       const cb = jest.fn();
       const afterCallback = jest.fn();
       loaderFactory.addLoaderListener('module', {

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
-import { Scanner, ArtusApplication } from '../../src';
+import { ArtusScanner, ArtusApplication } from '../../src';
 
 export async function createApp(baseDir: string) {
-  const scanner = new Scanner({
+  const scanner = new ArtusScanner({
     needWriteFile: false,
     configDir: 'config',
     extensions: ['.ts'],
@@ -10,7 +10,7 @@ export async function createApp(baseDir: string) {
   const manifest = await scanner.scan(baseDir);
 
   const app = new ArtusApplication();
-  await app.load(manifest.default, baseDir);
+  await app.load(manifest, baseDir);
   await app.run();
 
   return app;


### PR DESCRIPTION
- 抽离 LoaderFactory 的 find 能力，方便后续做 auto 的解构
- 重构 LoaderFactory.loadManifest 支持 Manifest V2
- 调整 Plugin 支持 Ref 模型
- 优化类型和边缘逻辑
- 调整单测确保 Loader 单测通

related #241 