### PR TITLE
fix(scanner): use individual store for loadConfigItemList

### DIFF
--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -34,14 +34,6 @@ export default class ConfigurationHandler {
     return mergeConfig(defaultConfig, ...envConfigList);
   }
 
-  getAllConfig(): ConfigObject {
-    const defaultConfig = this.configStore.get(ARTUS_DEFAULT_CONFIG_ENV.DEFAULT) ?? {};
-    const keys = Array.from(this.configStore.keys()).filter(
-      key => key !== ARTUS_DEFAULT_CONFIG_ENV.DEFAULT,
-    );
-    return mergeConfig(defaultConfig, ...keys.map(key => this.configStore.get(key) ?? {}));
-  }
-
   clearStore(): void {
     this.configStore.clear();
   }

--- a/src/scanner/task.ts
+++ b/src/scanner/task.ts
@@ -248,8 +248,6 @@ export class ScanTaskRunner {
       const taskItem = this.taskQueue.shift();
       await this.run(taskItem);
     }
-    // Clean up
-    this.app.configurationHandler.clearStore();
   }
 
   public dump(): Manifest {


### PR DESCRIPTION
`scanner/utils` 中的 `loadConfigItemList` 方法用于在扫描每个 Ref 时加载其内部的配置，为了保证函数类型配置工作正常，此前复用了 `app`，但此前仅在扫描任务完全结束时清理了一次 ConfigStore，所以可能在某些 ref 中拿到被不正常合并后的配置，造成加载异常。

本 PR 调整项包括：
- `loadConfigItemList` 调整实现
  - 通过在 async 过程中替换 configStore 指向，确保每次调用该方法时使用一干净的 Store，调用结束前还原
- 移除已无必要的清理逻辑，减少误解
- 移除已无调用的 `getAllConfig` 方法，减少误解
