### PR TITLE
refactor(exception): exception filter need to handle inheritance of error clazz

### DIFF
--- a/src/exception/utils.ts
+++ b/src/exception/utils.ts
@@ -3,6 +3,8 @@ import { Constructable, Container } from '@artus/injection';
 import { EXCEPTION_FILTER_DEFAULT_SYMBOL, EXCEPTION_FILTER_MAP_INJECT_ID } from './constant';
 import { ArtusStdError } from './impl';
 import { ExceptionFilterMapType, ExceptionFilterType } from './types';
+import { isClass } from '../utils/is';
+
 
 export const matchExceptionFilterClazz =  (err: Error, container: Container): Constructable<ExceptionFilterType> | null => {
   const filterMap: ExceptionFilterMapType = container.get(EXCEPTION_FILTER_MAP_INJECT_ID, {
@@ -11,18 +13,27 @@ export const matchExceptionFilterClazz =  (err: Error, container: Container): Co
   if (!filterMap) {
     return null;
   }
-  let targetFilterClazz: Constructable<ExceptionFilterType> | null = null;
+
+  // handle ArtusStdError with code simply
   if (err instanceof ArtusStdError && filterMap.has(err.code)) {
-    // handle ArtusStdError with code simply
-    targetFilterClazz = filterMap.get(err.code);
-  } else if (filterMap.has(err['constructor'] as Constructable<Error>)) {
-    // handle CustomErrorClazz
-    targetFilterClazz = filterMap.get(err['constructor'] as Constructable<Error>);
-  } else if (filterMap.has(EXCEPTION_FILTER_DEFAULT_SYMBOL)) {
-    // handle default ExceptionFilter
-    targetFilterClazz = filterMap.get(EXCEPTION_FILTER_DEFAULT_SYMBOL);
+    return filterMap.get(err.code);
   }
-  return targetFilterClazz;
+  
+  // handle CustomErrorClazz, loop inherit class
+  let errConstructor: Function = err['constructor'];
+  while(isClass(errConstructor)) { // until parent/self is not class
+    if (filterMap.has(errConstructor as Constructable<Error>)) {
+      return filterMap.get(errConstructor as Constructable<Error>);
+    }
+    errConstructor = Object.getPrototypeOf(errConstructor); // get parent clazz by prototype
+  }
+  
+  // handle default ExceptionFilter
+  if (filterMap.has(EXCEPTION_FILTER_DEFAULT_SYMBOL)) {
+    return filterMap.get(EXCEPTION_FILTER_DEFAULT_SYMBOL);
+  }
+
+  return null;
 };
 
 export const matchExceptionFilter = (err: Error, container: Container): ExceptionFilterType | null => {

--- a/test/exception_filter.test.ts
+++ b/test/exception_filter.test.ts
@@ -27,6 +27,8 @@ describe('test/exception_filter.test.ts', () => {
         ['custom', 'TestCustomError'],
         ['wrapped', 'APP:WRAPPED_ERROR'],
         ['APP:TEST_ERROR', 'APP:TEST_ERROR'],
+        ['inherit', 'TestInheritError'],
+        ['defaultInherit', 'TestDefaultInheritError'],
       ]) {
         const mockErrorService = app.container.get(MockErrorService);
         try {

--- a/test/fixtures/exception_filter/bootstrap.ts
+++ b/test/fixtures/exception_filter/bootstrap.ts
@@ -24,6 +24,8 @@ async function main() {
                 "TestAppCodeExceptionHandler",
                 "TestWrappedExceptionHandler",
                 "TestCustomExceptionHandler",
+                "TestDefaultInheritExceptionHandler",
+                "TestInheritExceptionHandler",
               ],
             },
             source: "app",

--- a/test/fixtures/exception_filter/error.ts
+++ b/test/fixtures/exception_filter/error.ts
@@ -12,3 +12,15 @@ export class TestWrappedError extends ArtusStdError {
 export class TestCustomError extends Error {
   name = 'TestCustomError';
 }
+
+export class TestDefaultInheritError extends Error {
+  name = 'TestDefaultInheritError';
+}
+
+export class TestBaseError extends Error {
+  name = 'TestBaseError';
+}
+
+export class TestInheritError extends TestBaseError {
+  name = 'TestInheritError';
+}

--- a/test/fixtures/exception_filter/filter.ts
+++ b/test/fixtures/exception_filter/filter.ts
@@ -1,6 +1,6 @@
 import { ArtusStdError, Catch, Inject } from '../../../src';
 import { ExceptionFilterType } from '../../../src/exception/types';
-import { TestCustomError, TestWrappedError } from './error';
+import { TestBaseError, TestCustomError, TestWrappedError } from './error';
 
 @Catch()
 export class TestDefaultExceptionHandler implements ExceptionFilterType {
@@ -38,6 +38,26 @@ export class TestCustomExceptionHandler implements ExceptionFilterType {
   mockSet: Set<string>;
 
   async catch(err: TestCustomError) {
+    this.mockSet.add(err.name);
+  }
+}
+
+@Catch(Error)
+export class TestDefaultInheritExceptionHandler implements ExceptionFilterType {
+  @Inject('mock_exception_set')
+  mockSet: Set<string>;
+
+  async catch(err: Error) {
+    this.mockSet.add(err.name);
+  }
+}
+
+@Catch(TestBaseError)
+export class TestInheritExceptionHandler implements ExceptionFilterType {
+  @Inject('mock_exception_set')
+  mockSet: Set<string>;
+
+  async catch(err: TestBaseError) {
     this.mockSet.add(err.name);
   }
 }

--- a/test/fixtures/exception_filter/service.ts
+++ b/test/fixtures/exception_filter/service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@artus/injection';
 import { ArtusStdError } from '../../../src';
-import { TestCustomError, TestWrappedError } from './error';
+import { TestCustomError, TestDefaultInheritError, TestInheritError, TestWrappedError } from './error';
 
 @Injectable()
 export default class MockErrorService {
@@ -13,6 +13,10 @@ export default class MockErrorService {
         throw new TestCustomError();
       case "wrapped":
         throw new TestWrappedError();
+      case "inherit":
+        throw new TestInheritError();
+      case "defaultInherit":
+        throw new TestDefaultInheritError();
       default:
         throw new ArtusStdError(target);
     }


### PR DESCRIPTION
之前考虑通过 instanceof 匹配错误类的话，需要对 Filter 全量 Map 做遍历，有性能损耗，所以匹配时直接用了 `Map().has(constructor)` 的方案；

但这种情况下，对于以下的继承场景将有遗漏，如下：

```ts
class BaseError extends Error {}
class InputError extends BaseError {}

@Catch(BaseError)
class SomeFilter implements ExceptionFilterType {
    catch(err) {
        // 这里是拦截不到 InputError 的
    }
}
```

所以计划匹配阶段增加对异常实例原型链的循环，从子到父，直到 prototype 不为 class（根级），期间如有命中直接返回（相当于越精确的 Filter 优先级越高，如上例 `@Catch(InputError)` > `@Catch(BaseError)`）；

以此策略支持有继承场景的 ExceptionFilter，考虑到异常的继承嵌套不会很长（通常比 Filter 数量小且可控），性能损失相对有限。
