### PR TITLE
fix(plugin): add artus dir to package path resolver for pnpm

### DIFF
--- a/src/plugin/common.ts
+++ b/src/plugin/common.ts
@@ -35,9 +35,11 @@ export function topologicalSort(pluginInstanceMap: Map<string, PluginType>, plug
 }
 
 // A util function of get package path for plugin
-export function getPackagePath(packageName: string, paths?: string[]): string {
-  const opts = paths ? { paths } : undefined;
-  return path.resolve(require.resolve(packageName, opts), '..');
+export function getPackagePath(packageName: string, paths: string[] = []): string {
+  const opts = {
+    paths: paths.concat(__dirname),
+  };
+  return path.dirname(require.resolve(packageName, opts));
 }
 
 export async function getInlinePackageEntryPath(packagePath: string): Promise<string> {


### PR DESCRIPTION
pnpm 可能出现依赖打平（flat）在 `node_modules/.pnpm/node_modules`；

这种场景下，只使用扫描的 baseDir 加载包，可能找不到包路径