### PR TITLE
refactor(plugin): use standard dfs instead of topological for stable sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artus/core",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Core package of Artus",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/plugin/common.ts
+++ b/src/plugin/common.ts
@@ -1,79 +1,86 @@
-import path from 'path';
-import compatibleRequire from '../utils/compatible_require';
-import { PluginType } from './types';
-import { LoggerType } from '../logger';
+import path from "path";
+import compatibleRequire from "../utils/compatible_require";
+import { PluginType } from "./types";
+import { LoggerType } from "../logger";
 
-export function sortPlugins(pluginInstanceMap: Map<string, PluginType>, logger: LoggerType) {
+export function sortPlugins(
+  pluginInstanceMap: Map<string, PluginType>,
+  logger: LoggerType,
+): PluginType[] {
   const sortedPlugins: PluginType[] = [];
   const visited: Record<string, boolean> = {};
 
-  while (sortedPlugins.length < pluginInstanceMap.size) {
-    let added = false;
+  const visit = (pluginName: string, depChain: string[] = []) => {
+    if (depChain.includes(pluginName)) {
+      throw new Error(
+        `Circular dependency found in plugins: ${depChain.join(", ")}`,
+      );
+    }
 
-    for (const [pluginName, plugin] of pluginInstanceMap) {
-      if (visited[pluginName]) {
-        continue;
-      }
+    if (visited[pluginName]) return;
 
-      let depsSatisfied = true;
+    visited[pluginName] = true;
+
+    const plugin = pluginInstanceMap.get(pluginName);
+    if (plugin) {
       for (const dep of plugin.metadata.dependencies ?? []) {
         const depPlugin = pluginInstanceMap.get(dep.name);
         if (!depPlugin || !depPlugin.enable) {
           if (dep.optional) {
-            logger?.warn(`Plugin ${plugin.name} need have optional dependency: ${dep.name}.`);
+            logger?.warn(
+              `Plugin ${plugin.name} need have optional dependency: ${dep.name}.`,
+            );
           } else {
-            throw new Error(`Plugin ${plugin.name} need have dependency: ${dep.name}.`);
+            throw new Error(
+              `Plugin ${plugin.name} need have dependency: ${dep.name}.`,
+            );
           }
-        } else if (!visited[dep.name]) { // Plugin exist and enabled, need check visited
-          depsSatisfied = false;
+        } else {
+          // Plugin exist and enabled, need visit
+          visit(dep.name, depChain.concat(pluginName));
         }
       }
-
-      if (depsSatisfied) {
-        sortedPlugins.push(plugin);
-        visited[plugin.name] = true;
-        added = true;
-      }
+      sortedPlugins.push(plugin);
     }
+  };
 
-    if (!added) {
-      const cyclePluginNames: string[] = [];
-      const sortedPluginSet = new Set(sortedPlugins.map(p => p.name));
-      for (const pluginName of pluginInstanceMap.keys()) {
-        if (!sortedPluginSet.has(pluginName)) {
-          cyclePluginNames.push(pluginName);
-        }
-      }
-      throw new Error(`Circular dependency found in plugins: ${cyclePluginNames.join(', ')}`);
-    }
+  for (const pluginName of pluginInstanceMap.keys()) {
+    visit(pluginName);
   }
 
   return sortedPlugins;
 }
 
 // A util function of get package path for plugin
-export function getPackagePath(packageName: string, paths: string[] = []): string {
+export function getPackagePath(
+  packageName: string,
+  paths: string[] = [],
+): string {
   const opts = {
     paths: paths.concat(__dirname),
   };
   return path.dirname(require.resolve(packageName, opts));
 }
 
-export async function getInlinePackageEntryPath(packagePath: string): Promise<string> {
+export async function getInlinePackageEntryPath(
+  packagePath: string,
+): Promise<string> {
   const pkgJson = await compatibleRequire(`${packagePath}/package.json`);
-  let entryFilePath = '';
+  let entryFilePath = "";
   if (pkgJson.exports) {
     if (Array.isArray(pkgJson.exports)) {
       throw new Error(`inline package multi exports is not supported`);
-    } else if (typeof pkgJson.exports === 'string') {
+    } else if (typeof pkgJson.exports === "string") {
       entryFilePath = pkgJson.exports;
-    } else if (pkgJson.exports?.['.']) {
-      entryFilePath = pkgJson.exports['.'];
+    } else if (pkgJson.exports?.["."]) {
+      entryFilePath = pkgJson.exports["."];
     }
   }
   if (!entryFilePath && pkgJson.main) {
     entryFilePath = pkgJson.main;
   }
   // will use package root path if no entry file found
-  return entryFilePath ? path.resolve(packagePath, entryFilePath, '..') : packagePath;
+  return entryFilePath
+    ? path.resolve(packagePath, entryFilePath, "..")
+    : packagePath;
 }

--- a/src/plugin/common.ts
+++ b/src/plugin/common.ts
@@ -1,37 +1,54 @@
 import path from 'path';
 import compatibleRequire from '../utils/compatible_require';
 import { PluginType } from './types';
+import { LoggerType } from '../logger';
 
-// A utils function that toplogical sort plugins
-export function topologicalSort(pluginInstanceMap: Map<string, PluginType>, pluginDepEdgeList: [string, string][]): string[] {
-  const res: string[] = [];
-  const indegree: Map<string, number> = new Map();
+export function sortPlugins(pluginInstanceMap: Map<string, PluginType>, logger: LoggerType) {
+  const sortedPlugins: PluginType[] = [];
+  const visited: Record<string, boolean> = {};
 
-  pluginDepEdgeList.forEach(([to]) => {
-    indegree.set(to, (indegree.get(to) ?? 0) + 1);
-  });
+  while (sortedPlugins.length < pluginInstanceMap.size) {
+    let added = false;
 
-  const queue: string[] = [];
+    for (const [pluginName, plugin] of pluginInstanceMap) {
+      if (visited[pluginName]) {
+        continue;
+      }
 
-  for (const [name] of pluginInstanceMap) {
-    if (!indegree.has(name)) {
-      queue.push(name);
-    }
-  }
-
-  while(queue.length) {
-    const cur = queue.shift()!;
-    res.push(cur);
-    for (const [to, from] of pluginDepEdgeList) {
-      if (from === cur) {
-        indegree.set(to, (indegree.get(to) ?? 0) - 1);
-        if (indegree.get(to) === 0) {
-          queue.push(to);
+      let depsSatisfied = true;
+      for (const dep of plugin.metadata.dependencies ?? []) {
+        const depPlugin = pluginInstanceMap.get(dep.name);
+        if (!depPlugin || !depPlugin.enable) {
+          if (dep.optional) {
+            logger?.warn(`Plugin ${plugin.name} need have optional dependency: ${dep.name}.`);
+          } else {
+            throw new Error(`Plugin ${plugin.name} need have dependency: ${dep.name}.`);
+          }
+        } else if (!visited[dep.name]) { // Plugin exist and enabled, need check visited
+          depsSatisfied = false;
         }
       }
+
+      if (depsSatisfied) {
+        sortedPlugins.push(plugin);
+        visited[plugin.name] = true;
+        added = true;
+      }
+    }
+
+    if (!added) {
+      const cyclePluginNames: string[] = [];
+      const sortedPluginSet = new Set(sortedPlugins.map(p => p.name));
+      for (const pluginName of pluginInstanceMap.keys()) {
+        if (!sortedPluginSet.has(pluginName)) {
+          cyclePluginNames.push(pluginName);
+        }
+      }
+      throw new Error(`Circular dependency found in plugins: ${cyclePluginNames.join(', ')}`);
     }
   }
-  return res;
+
+  return sortedPlugins;
 }
 
 // A util function of get package path for plugin

--- a/src/plugin/factory.ts
+++ b/src/plugin/factory.ts
@@ -1,33 +1,17 @@
-import { topologicalSort } from './common';
+import { sortPlugins } from './common';
 import { Plugin } from './impl';
 import { PluginConfigItem, PluginCreateOptions, PluginMap, PluginType } from './types';
 
 export class PluginFactory {
-  static async create(name: string, item: PluginConfigItem, opts?: PluginCreateOptions): Promise<PluginType> {
-    const pluginInstance = new Plugin(name, item, opts);
-    await pluginInstance.init();
-    return pluginInstance;
-  }
-
   static async createFromConfig(config: Record<string, PluginConfigItem>, opts?: PluginCreateOptions): Promise<PluginType[]> {
     const pluginInstanceMap: PluginMap = new Map();
     for (const [name, item] of Object.entries(config)) {
-      const pluginInstance = await PluginFactory.create(name, item, opts);
-      if (pluginInstance.enable) {
+      if (item.enable) {
+        const pluginInstance = new Plugin(name, item);
+        await pluginInstance.init();
         pluginInstanceMap.set(name, pluginInstance);
       }
     }
-    let pluginDepEdgeList: [string, string][] = [];
-    // Topological sort plugins
-    for (const [_name, pluginInstance] of pluginInstanceMap) {
-      pluginInstance.checkDepExisted(pluginInstanceMap);
-      pluginDepEdgeList = pluginDepEdgeList.concat(pluginInstance.getDepEdgeList());
-    }
-    const pluginSortResult: string[] = topologicalSort(pluginInstanceMap, pluginDepEdgeList);
-    if (pluginSortResult.length !== pluginInstanceMap.size) {
-      const diffPlugin = [...pluginInstanceMap.keys()].filter(name => !pluginSortResult.includes(name));
-      throw new Error(`There is a cycle in the dependencies, wrong plugin is ${diffPlugin.join(',')}.`);
-    }
-    return pluginSortResult.map(name => pluginInstanceMap.get(name)!);
+    return sortPlugins(pluginInstanceMap, opts?.logger);
   }
 }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -39,6 +39,4 @@ export interface PluginType {
   metaFilePath: string;
 
   init(): Promise<void>;
-  checkDepExisted(map: PluginMap): void;
-  getDepEdgeList(): [string, string][];
 }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -11,44 +11,27 @@ describe('test/plugin.test.ts', () => {
         'plugin-a': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_a`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_a/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-b': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_b`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_b/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-c': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_c`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_c/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
+        },
+        'plugin-d': {
+          enable: true,
+          path: path.resolve(__dirname, `${pluginPrefix}/plugin_d`),
         },
       };
       const pluginList = await PluginFactory.createFromConfig(mockPluginConfig);
-      expect(pluginList.length).toEqual(3);
+      expect(pluginList.length).toEqual(4);
       pluginList.forEach(plugin => {
         expect(plugin).toBeInstanceOf(Plugin);
         expect(plugin.enable).toBeTruthy();
       });
-      expect(pluginList.map(plugin => plugin.name)).toStrictEqual(['plugin-c', 'plugin-b', 'plugin-a']);
+      expect(pluginList.map(plugin => plugin.name)).toStrictEqual(['plugin-c', 'plugin-b', 'plugin-a', 'plugin-d']);
     });
 
     it('should not load plugin with wrong order', async () => {
@@ -56,60 +39,29 @@ describe('test/plugin.test.ts', () => {
         'plugin-a': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_a`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_a/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-b': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_b`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_b/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-c': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_c`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_c/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
+        },
+        'plugin-d': {
+          enable: true,
+          path: path.resolve(__dirname, `${pluginPrefix}/plugin_d`),
         },
         'plugin-wrong-a': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_wrong_a`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_wrong_a/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-wrong-b': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_wrong_b`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_wrong_b/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
       };
-      expect(async () => {
+      await expect(async () => {
         await PluginFactory.createFromConfig(mockPluginConfig);
       }).rejects.toThrowError(new Error(`Circular dependency found in plugins: plugin-wrong-a, plugin-wrong-b`));
     });
@@ -119,13 +71,6 @@ describe('test/plugin.test.ts', () => {
         'plugin-a': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_a`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_a/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
       };
       expect(async () => {
@@ -138,38 +83,17 @@ describe('test/plugin.test.ts', () => {
         'plugin-a': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_a`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_a/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-b': {
           enable: false,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_b`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_b/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-c': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_c`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_c/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
       };
-      expect(async () => {
+      await expect(async () => {
         await PluginFactory.createFromConfig(mockPluginConfig);
       }).rejects.toThrowError(new Error(`Plugin plugin-a need have dependency: plugin-b.`));
     });
@@ -179,13 +103,6 @@ describe('test/plugin.test.ts', () => {
         'plugin-d': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_d`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_d/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
       };
 
@@ -209,27 +126,13 @@ describe('test/plugin.test.ts', () => {
 
     it('should not throw if optional dependence disabled', async () => {
       const mockPluginConfig = {
-        'plugin-c': {
+        'plugin-b': {
           enable: false,
-          path: path.resolve(__dirname, `${pluginPrefix}/plugin_c`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_c/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
+          path: path.resolve(__dirname, `${pluginPrefix}/plugin_b`),
         },
         'plugin-d': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_d`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_d/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
       };
 
@@ -256,24 +159,10 @@ describe('test/plugin.test.ts', () => {
         'plugin-d': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_d`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_d/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
         'plugin-c': {
           enable: true,
           path: path.resolve(__dirname, `${pluginPrefix}/plugin_c`),
-          manifest: {
-            pluginMeta: {
-              path: path.resolve(__dirname, `${pluginPrefix}/plugin_c/meta.js`),
-              extname: '.js',
-              filename: 'meta.js',
-            },
-          },
         },
       };
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -4,7 +4,7 @@ import { Logger, Plugin, PluginFactory } from '../src';
 
 const pluginPrefix = 'fixtures/plugins';
 
-describe('test/app.test.ts', () => {
+describe('test/plugin.test.ts', () => {
   describe('app with config', () => {
     it('should load plugin with dep order', async () => {
       const mockPluginConfig = {
@@ -111,7 +111,7 @@ describe('test/app.test.ts', () => {
       };
       expect(async () => {
         await PluginFactory.createFromConfig(mockPluginConfig);
-      }).rejects.toThrowError(new Error(`There is a cycle in the dependencies, wrong plugin is plugin-wrong-a,plugin-wrong-b.`));
+      }).rejects.toThrowError(new Error(`Circular dependency found in plugins: plugin-wrong-a, plugin-wrong-b`));
     });
 
     it('should throw if dependencies missing', async () => {


### PR DESCRIPTION
## Background

之前插件的按依赖排序使用了拓扑排序算法；

- 优点是有向无环图理论复杂度低，可以较容易检查循环依赖；
- 缺点是不稳定排序，可能造成 config 内锚定的无关依赖顺序漂移；

而插件排序场景中对于不能靠 `dependencies` 声明来实现的，较普遍使用 pluginConfig 中的顺序做依赖顺序保障，而拓扑排序使顺序漂移问题变得不易发现和处理。

## Example

例如，当我们有这段配置时：

```js
[
  { name: 'a', deps: [ 'b', 'c' ] },
  { name: 'b', deps: [ 'c' ] },
  { name: 'c', deps: [] },
  { name: 'd', deps: [ 'c' ] }
]
```

依赖链路为：

```plain
a -> b -> c
a -> c
b -> c
d -> c
```

期待的顺序为 `c, b, a, d`，即对于 a / d 作为无关项保持配置中的顺序；

然而，因为拓扑排序不稳定，最终顺序与依赖链长度有关（indegree 出队顺序），所以结果会是 `c, b, d, a`，如果 a / d 间有相互影响，将产生不可用现象

## Solution

综上，有必要对该部分做出改变

该 PR 通过 DFS 重新实现 `PluginFactory.createFromConfig` 方法，在递归过程中进行 `optional` 和循环依赖检查；

同时优化了 Plugin 类的实现代码，移除了无用方法;

调整了 plugin 相关单测，顺序保证增加到 4 个，并使用上述的依赖链 case 做验证