### PR TITLE
fix: reverse emit function list when beforeClose hook

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -80,7 +80,8 @@ export class ArtusApplication implements Application {
 
   async close(exit = false) {
     try {
-      await this.lifecycleManager.emitHook('beforeClose');
+      // reverse emitHook to avoid plugin closed before app hook
+      await this.lifecycleManager.emitHook('beforeClose', null, true);
     } catch (e) {
       throw new Error(e);
     }

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -70,7 +70,7 @@ export class LifecycleManager {
     }
   }
 
-  async emitHook<T = unknown>(hookName: string, payload?: T) {
+  async emitHook<T = unknown>(hookName: string, payload?: T, reverse = false) {
     if (!this.enable) {
       return;
     }
@@ -83,6 +83,9 @@ export class LifecycleManager {
     }
     // lifecycle hook should only trigger one time
     this.hookFnMap.delete(hookName);
+    if (reverse) {
+      fnList.reverse();
+    }
     for (const hookFn of fnList) {
       await hookFn({
         app: this.app,

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -46,9 +46,9 @@ describe('test/lifecycle.test.ts', () => {
       'pluginA_didReady',
       'pluginB_didReady',
       'app_didReady',
-      'pluginA_beforeClose',
-      'pluginB_beforeClose',
       'app_beforeClose',
+      'pluginB_beforeClose',
+      'pluginA_beforeClose',
     ]);
   });
 
@@ -84,9 +84,9 @@ describe('test/lifecycle.test.ts', () => {
       'pluginA_didReady',
       'pluginB_didReady',
       'app_didReady',
-      'pluginA_beforeClose',
-      'pluginB_beforeClose',
       'app_beforeClose',
+      'pluginB_beforeClose',
+      'pluginA_beforeClose',
     ]);
   });
 


### PR DESCRIPTION
beforeClose 钩子通常用于进行业务逻辑的收尾处理，此时仍可能使用插件提供的 Client；

正向触发 hook 可能造成插件中的链接比应用更早被回收，不符合预期；

所以简单地针对这个钩子，在 emitHook 阶段反转 fnList