### PR TITLE
fix: merge plugin config when load because of plugin preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,3 @@ lib
 
 # OSX
 .DS_Store
-
-!test/fixtures/frameworks/layer/foo/foo2/node_modules

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -53,7 +53,6 @@ export const DEFAULT_LOADER_LIST_WITH_ORDER = [
   'exception',
   'exception-filter',
   'plugin-meta',
-  'framework-config',
   'package-json',
   'module',
   'lifecycle-hook-unit',

--- a/src/loader/impl/config.ts
+++ b/src/loader/impl/config.ts
@@ -41,11 +41,6 @@ class ConfigLoader implements Loader {
   async load(item: ManifestItem) {
     const { namespace, env } = getConfigMetaFromFilename(item.filename);
     let configObj = await this.loadConfigFile(item);
-    // if (namespace === 'plugin') {
-    // configObj = {
-    //  plugin: await PluginFactory.formatPluginConfig(configObj, item),
-    // };
-    // } else
     if (namespace) {
       configObj = {
         [namespace]: configObj,

--- a/src/loader/types.ts
+++ b/src/loader/types.ts
@@ -9,6 +9,7 @@ export interface RefMapItem {
   relativedPath?: string;
   packageVersion?: string;
   pluginMetadata?: PluginMetadata;
+  pluginConfig: PluginConfigEnvMap;
   items: ManifestItem[];
 }
 // Key: RefName => RefMapItem
@@ -16,8 +17,8 @@ export type RefMap = Record<string, RefMapItem>;
 
 export interface Manifest {
   version: '2';
-  pluginConfig: PluginConfigEnvMap;
   refMap: RefMap;
+  extraPluginConfig?: PluginConfig;
 }
 
 export interface ManifestItem<LoaderState = unknown> extends Record<string, any> {

--- a/src/scanner/utils.ts
+++ b/src/scanner/utils.ts
@@ -52,7 +52,7 @@ export const loadConfigItemList = async <T = ConfigObject>(configItemList: Manif
   }
 
   // Use temp Map to store config
-  const configEnvMap: Map<string, T> = new Map();
+  const configEnvMap: Record<string, T> = {};
   const stashedConfigStore = app.configurationHandler.configStore;
   app.configurationHandler.configStore = configEnvMap;
 
@@ -65,7 +65,7 @@ export const loadConfigItemList = async <T = ConfigObject>(configItemList: Manif
   // Restore config store
   app.configurationHandler.configStore = stashedConfigStore;
 
-  return Object.fromEntries(configEnvMap.entries());
+  return configEnvMap;
 };
 
 export const resolvePluginConfigItemRef = async (

--- a/test/__snapshots__/scanner.test.ts.snap
+++ b/test/__snapshots__/scanner.test.ts.snap
@@ -2,32 +2,12 @@
 
 exports[`test/scanner.test.ts should be scan application 1`] = `
 {
-  "pluginConfig": {
-    "default": {
-      "mysql": {
-        "enable": false,
-        "refName": "src/mysql_plugin",
-      },
-      "redis": {
-        "enable": true,
-        "refName": "src/redis_plugin",
-      },
-      "testDuplicate": {
-        "enable": false,
-        "refName": "@artus/injection",
-      },
-    },
-    "dev": {
-      "testDuplicate": {
-        "enable": true,
-        "refName": "src/test_duplicate_plugin",
-      },
-    },
-  },
+  "extraPluginConfig": {},
   "refMap": {
     "@artus/injection": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "relativedPath": "../../../node_modules/@artus/injection/lib",
     },
     "_app": {
@@ -154,6 +134,28 @@ exports[`test/scanner.test.ts should be scan application 1`] = `
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "mysql": {
+            "enable": false,
+            "refName": "src/mysql_plugin",
+          },
+          "redis": {
+            "enable": true,
+            "refName": "src/redis_plugin",
+          },
+          "testDuplicate": {
+            "enable": false,
+            "refName": "@artus/injection",
+          },
+        },
+        "dev": {
+          "testDuplicate": {
+            "enable": true,
+            "refName": "src/test_duplicate_plugin",
+          },
+        },
+      },
       "relativedPath": "",
     },
     "src/redis_plugin": {
@@ -173,6 +175,7 @@ exports[`test/scanner.test.ts should be scan application 1`] = `
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "exclude": [
           "not_to_be_scanned_dir",
@@ -185,6 +188,7 @@ exports[`test/scanner.test.ts should be scan application 1`] = `
     "src/test_duplicate_plugin": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "name": "testDuplicate",
       },
@@ -197,54 +201,17 @@ exports[`test/scanner.test.ts should be scan application 1`] = `
 
 exports[`test/scanner.test.ts should scan application with nesting preset a which defined in options 1`] = `
 {
-  "pluginConfig": {
-    "default": {
-      "a": {
-        "enable": false,
-        "refName": "../plugins/plugin_a",
-      },
-      "b": {
-        "enable": false,
-        "refName": "../plugins/plugin_b",
-      },
-      "c": {
-        "enable": false,
-        "refName": "../plugins/plugin_c",
-      },
-      "d": {
-        "enable": true,
-        "refName": "../plugins/plugin_d",
-      },
-      "plugin-with-entry-a": {
-        "enable": true,
-        "refName": "../plugins/plugin_with_entry_a",
-      },
-      "plugin-with-entry-b": {
-        "enable": true,
-        "refName": "../plugins/plugin_with_entry_b",
-      },
-      "plugin-with-entry-c": {
-        "enable": false,
-        "refName": "../plugins/plugin_with_entry_c",
-      },
-      "preset_a": {
-        "enable": true,
-        "refName": "../plugins/preset_a",
-      },
-      "preset_b": {
-        "enable": true,
-        "refName": "../plugins/preset_b",
-      },
-      "preset_c": {
-        "enable": true,
-        "refName": "../plugins/preset_c",
-      },
+  "extraPluginConfig": {
+    "preset_a": {
+      "enable": true,
+      "refName": "../plugins/preset_a",
     },
   },
   "refMap": {
     "../plugins/plugin_a": {
       "items": [],
       "packageVersion": "0.0.1",
+      "pluginConfig": {},
       "pluginMetadata": {
         "dependencies": [
           {
@@ -262,6 +229,7 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
     "../plugins/plugin_b": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "dependencies": [
           {
@@ -275,6 +243,7 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
     "../plugins/plugin_d": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "dependencies": [
           {
@@ -289,6 +258,7 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
     "../plugins/plugin_with_entry_a": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "name": "plugin-with-entry-a",
       },
@@ -297,6 +267,7 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
     "../plugins/plugin_with_entry_b": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "name": "plugin-with-entry-b",
       },
@@ -317,6 +288,25 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "a": {
+            "enable": false,
+          },
+          "plugin-with-entry-a": {
+            "enable": true,
+            "refName": "../plugins/plugin_with_entry_a",
+          },
+          "preset_b": {
+            "enable": true,
+            "refName": "../plugins/preset_b",
+          },
+          "preset_c": {
+            "enable": true,
+            "refName": "../plugins/preset_c",
+          },
+        },
+      },
       "pluginMetadata": {
         "name": "preset_a",
       },
@@ -337,6 +327,22 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "a": {
+            "enable": true,
+            "refName": "../plugins/plugin_a",
+          },
+          "b": {
+            "enable": true,
+            "refName": "../plugins/plugin_b",
+          },
+          "plugin-with-entry-b": {
+            "enable": true,
+            "refName": "../plugins/plugin_with_entry_b",
+          },
+        },
+      },
       "pluginMetadata": {
         "name": "preset_b",
       },
@@ -357,6 +363,26 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "b": {
+            "enable": false,
+            "refName": "../plugins/plugin_b",
+          },
+          "c": {
+            "enable": false,
+            "refName": "../plugins/plugin_c",
+          },
+          "d": {
+            "enable": true,
+            "refName": "../plugins/plugin_d",
+          },
+          "plugin-with-entry-c": {
+            "enable": false,
+            "refName": "../plugins/plugin_with_entry_c",
+          },
+        },
+      },
       "pluginMetadata": {
         "name": "preset_c",
       },
@@ -365,6 +391,7 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
     "_app": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "relativedPath": "",
     },
   },
@@ -374,30 +401,12 @@ exports[`test/scanner.test.ts should scan application with nesting preset a whic
 
 exports[`test/scanner.test.ts should scan application with single preset b which defined in config 1`] = `
 {
-  "pluginConfig": {
-    "default": {
-      "a": {
-        "enable": true,
-        "refName": "../plugins/plugin_a",
-      },
-      "b": {
-        "enable": true,
-        "refName": "../plugins/plugin_b",
-      },
-      "plugin-with-entry-b": {
-        "enable": true,
-        "refName": "../plugins/plugin_with_entry_b",
-      },
-      "preset_b": {
-        "enable": true,
-        "refName": "../plugins/preset_b",
-      },
-    },
-  },
+  "extraPluginConfig": {},
   "refMap": {
     "../plugins/plugin_a": {
       "items": [],
       "packageVersion": "0.0.1",
+      "pluginConfig": {},
       "pluginMetadata": {
         "dependencies": [
           {
@@ -415,6 +424,7 @@ exports[`test/scanner.test.ts should scan application with single preset b which
     "../plugins/plugin_b": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "dependencies": [
           {
@@ -428,6 +438,7 @@ exports[`test/scanner.test.ts should scan application with single preset b which
     "../plugins/plugin_with_entry_b": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "name": "plugin-with-entry-b",
       },
@@ -448,6 +459,22 @@ exports[`test/scanner.test.ts should scan application with single preset b which
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "a": {
+            "enable": true,
+            "refName": "../plugins/plugin_a",
+          },
+          "b": {
+            "enable": true,
+            "refName": "../plugins/plugin_b",
+          },
+          "plugin-with-entry-b": {
+            "enable": true,
+            "refName": "../plugins/plugin_with_entry_b",
+          },
+        },
+      },
       "pluginMetadata": {
         "name": "preset_b",
       },
@@ -468,6 +495,14 @@ exports[`test/scanner.test.ts should scan application with single preset b which
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "preset_b": {
+            "enable": true,
+            "refName": "../plugins/preset_b",
+          },
+        },
+      },
       "relativedPath": "",
     },
   },
@@ -477,34 +512,17 @@ exports[`test/scanner.test.ts should scan application with single preset b which
 
 exports[`test/scanner.test.ts should scan application with single preset c which defined in options 1`] = `
 {
-  "pluginConfig": {
-    "default": {
-      "b": {
-        "enable": false,
-        "refName": "../plugins/plugin_b",
-      },
-      "c": {
-        "enable": false,
-        "refName": "../plugins/plugin_c",
-      },
-      "d": {
-        "enable": true,
-        "refName": "../plugins/plugin_d",
-      },
-      "plugin-with-entry-c": {
-        "enable": false,
-        "refName": "../plugins/plugin_with_entry_c",
-      },
-      "preset_c": {
-        "enable": true,
-        "refName": "../plugins/preset_c",
-      },
+  "extraPluginConfig": {
+    "preset_c": {
+      "enable": true,
+      "refName": "../plugins/preset_c",
     },
   },
   "refMap": {
     "../plugins/plugin_d": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "pluginMetadata": {
         "dependencies": [
           {
@@ -531,6 +549,26 @@ exports[`test/scanner.test.ts should scan application with single preset c which
         },
       ],
       "packageVersion": undefined,
+      "pluginConfig": {
+        "default": {
+          "b": {
+            "enable": false,
+            "refName": "../plugins/plugin_b",
+          },
+          "c": {
+            "enable": false,
+            "refName": "../plugins/plugin_c",
+          },
+          "d": {
+            "enable": true,
+            "refName": "../plugins/plugin_d",
+          },
+          "plugin-with-entry-c": {
+            "enable": false,
+            "refName": "../plugins/plugin_with_entry_c",
+          },
+        },
+      },
       "pluginMetadata": {
         "name": "preset_c",
       },
@@ -539,6 +577,7 @@ exports[`test/scanner.test.ts should scan application with single preset c which
     "_app": {
       "items": [],
       "packageVersion": undefined,
+      "pluginConfig": {},
       "relativedPath": "",
     },
   },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -9,6 +9,7 @@ describe("test/config.test.ts", () => {
       const app = await main();
       expect(app.config).toEqual({
         name: "test-for-config",
+        plugin: {},
         test: 1,
         arr: [4, 5, 6],
       });

--- a/test/fixtures/app_koa_with_ts/src/bootstrap.ts
+++ b/test/fixtures/app_koa_with_ts/src/bootstrap.ts
@@ -8,9 +8,9 @@ export const app: ArtusApplication = new ArtusApplication();
 async function main() {
   await app.load({
     version: '2',
-    pluginConfig: {},
     refMap: {
       _app: {
+        pluginConfig: {},
         items: [
           {
             path: path.resolve(__dirname, "./lifecycle"),

--- a/test/fixtures/app_with_config/bootstrap.ts
+++ b/test/fixtures/app_with_config/bootstrap.ts
@@ -7,9 +7,9 @@ async function main() {
   const app = new ArtusApplication();
   await app.load({
     version: "2",
-    pluginConfig: {},
     refMap: {
       _app: {
+        pluginConfig: {},
         items: [
           {
             path: path.resolve(__dirname, "./app"),

--- a/test/fixtures/exception_filter/bootstrap.ts
+++ b/test/fixtures/exception_filter/bootstrap.ts
@@ -9,9 +9,9 @@ async function main() {
   });
   await app.load({
     version: "2",
-    pluginConfig: {},
     refMap: {
       _app: {
+        pluginConfig: {},
         items: [
           {
             path: path.resolve(__dirname, "./filter"),

--- a/test/fixtures/exception_invalid_filter/bootstrap.ts
+++ b/test/fixtures/exception_invalid_filter/bootstrap.ts
@@ -9,9 +9,9 @@ async function main() {
   });
   await app.load({
     version: "2",
-    pluginConfig: {},
     refMap: {
       _app: {
+        pluginConfig: {},
         items: [
           {
             path: path.resolve(__dirname, "./filter"),

--- a/test/fixtures/exception_with_ts_yaml/bootstrap.ts
+++ b/test/fixtures/exception_with_ts_yaml/bootstrap.ts
@@ -6,9 +6,9 @@ async function main() {
   const app = new ArtusApplication();
   await app.load({
     version: "2",
-    pluginConfig: {},
     refMap: {
       _app: {
+        pluginConfig: {},
         items: [
           {
             path: path.resolve(__dirname, "./app"),

--- a/test/fixtures/logger/src/index.ts
+++ b/test/fixtures/logger/src/index.ts
@@ -5,9 +5,9 @@ const rootDir = path.resolve(__dirname, "./");
 
 const defaultManifest: Manifest = {
   version: "2",
-  pluginConfig: {},
   refMap: {
     _app: {
+      pluginConfig: {},
       items: [
         {
           path: path.resolve(rootDir, "./test_clazz"),
@@ -21,9 +21,9 @@ const defaultManifest: Manifest = {
 
 export const manifestWithCustomLogger: Manifest = {
   version: "2",
-  pluginConfig: {},
   refMap: {
     _app: {
+      pluginConfig: {},
       items: [
         ...defaultManifest.refMap._app.items,
         {

--- a/test/fixtures/module_with_custom_loader/src/index.ts
+++ b/test/fixtures/module_with_custom_loader/src/index.ts
@@ -5,9 +5,9 @@ const rootDir = path.resolve(__dirname, "./");
 
 export default {
   version: "2",
-  pluginConfig: {},
   refMap: {
     _app: {
+      pluginConfig: {},
       items: [
         {
           path: path.resolve(rootDir, "./test_clazz"),

--- a/test/fixtures/module_with_ts/src/index.ts
+++ b/test/fixtures/module_with_ts/src/index.ts
@@ -5,9 +5,9 @@ const rootDir = path.resolve(__dirname, "./");
 
 export default {
   version: "2",
-  pluginConfig: {},
   refMap: {
     _app: {
+      pluginConfig: {},
       items: [
         {
           path: path.resolve(rootDir, "./test_service_a"),


### PR DESCRIPTION
之前在 Scan 阶段预处理的 pluginConfig，存在边界 case：

- 插件合集 a 内 default 启用了插件 b
- app 在 prod 环境未启用插件合集 a
- 但预处理过程中把全部 default 合并，全部 prod 合并
- 预期应为 prod 是 a 禁用，所以不涉及 b 的工作
- 但实际出现总和 default 中 b 启用，prod 中 a 禁用，合并结果中 b 仍被启用

本 PR 调整了 Scanner & Loader 的插件配置部分逻辑：

- 将 pluginConfig 字段分拆到 refMap 和 extraPluginConfig（扫描时指定的）；
- load 阶段以 ref（插件/应用）为单位，每层按环境合并插件配置；
- 用上面按环境合并的配置排序、加载 itemList
